### PR TITLE
docs: complete v0.3.0 documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ description: Deterministic Rust backend generation from explicit YAML resources.
 url: https://shaperail.io
 baseurl: ""
 repository: shaperail/shaperail
-release_version: 0.2.2
+release_version: 0.3.0
 markdown: kramdown
 permalink: pretty
 remote_theme: just-the-docs/just-the-docs@v0.12.0

--- a/docs/api-responses.md
+++ b/docs/api-responses.md
@@ -14,7 +14,7 @@ list endpoints.
 
 ## Response envelope
 
-### Single record (GET /resources/:id, PATCH /resources/:id)
+### Single record (GET /v1/resources/:id, PATCH /v1/resources/:id)
 
 HTTP 200 for GET and PATCH. HTTP 201 for POST.
 
@@ -30,7 +30,7 @@ HTTP 200 for GET and PATCH. HTTP 201 for POST.
 }
 ```
 
-### List (GET /resources)
+### List (GET /v1/resources)
 
 The `meta` object varies by pagination style.
 
@@ -68,7 +68,20 @@ last page.
 }
 ```
 
-### Bulk operations
+### Bulk create (POST /resources/bulk)
+
+Send an array of records in the request body:
+
+```json
+{
+  "data": [
+    { "email": "alice@example.com", "name": "Alice", "role": "admin" },
+    { "email": "bob@example.com", "name": "Bob", "role": "member" }
+  ]
+}
+```
+
+Response (HTTP 201):
 
 ```json
 {
@@ -82,7 +95,57 @@ last page.
 }
 ```
 
-### Delete (DELETE /resources/:id)
+Declare the endpoint to enable bulk create:
+
+```yaml
+endpoints:
+  bulk_create:
+    method: POST
+    path: /users/bulk
+    auth: [admin]
+    input: [email, name, role, org_id]
+```
+
+All records are inserted in a single transaction — if any record fails
+validation, the entire batch is rolled back.
+
+### Bulk delete (DELETE /resources/bulk)
+
+Send an array of IDs in the request body:
+
+```json
+{
+  "ids": [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+  ]
+}
+```
+
+Response (HTTP 200):
+
+```json
+{
+  "data": {
+    "deleted": 2
+  }
+}
+```
+
+Declare the endpoint:
+
+```yaml
+endpoints:
+  bulk_delete:
+    method: DELETE
+    path: /users/bulk
+    auth: [admin]
+```
+
+Bulk delete respects `soft_delete: true` when declared — it sets `deleted_at`
+instead of removing rows.
+
+### Delete (DELETE /v1/resources/:id)
 
 Returns HTTP 204 No Content with an empty body.
 
@@ -153,13 +216,17 @@ For all other error codes, `details` is `null`.
 All list endpoints accept the parameters below. Which filters and search fields
 are available depends on the resource file for that endpoint.
 
+All URLs are prefixed with `/v{version}` based on the resource's `version`
+field. The examples below use `/v1` — adjust the prefix if your resource uses a
+different version number.
+
 ### Filtering
 
 Use bracket syntax on the `filter` key. Only fields declared in the endpoint's
 `filters` list are accepted; all others are silently ignored.
 
 ```
-GET /users?filter[role]=admin&filter[org_id]=550e8400-e29b-41d4-a716-446655440000
+GET /v1/users?filter[role]=admin&filter[org_id]=550e8400-e29b-41d4-a716-446655440000
 ```
 
 Filters produce exact-match `WHERE` clauses (`field = value`).
@@ -170,7 +237,7 @@ Pass a comma-separated list of field names to `sort`. Prefix a field with `-`
 for descending order; no prefix means ascending.
 
 ```
-GET /users?sort=-created_at,name
+GET /v1/users?sort=-created_at,name
 ```
 
 This sorts by `created_at DESC`, then `name ASC`. Only fields declared in the
@@ -182,7 +249,7 @@ Pass a plain-text term to `search`. The server performs a PostgreSQL full-text
 search across the fields declared in the endpoint's `search` list.
 
 ```
-GET /users?search=alice
+GET /v1/users?search=alice
 ```
 
 The generated SQL uses `to_tsvector('english', ...)` and `plainto_tsquery`,
@@ -194,8 +261,8 @@ Cursor pagination is the default when `pagination: cursor` is set (or when no
 pagination style is specified).
 
 ```
-GET /users?limit=10
-GET /users?limit=10&after=NTUwZTg0MDAtZTI5Yi00MWQ0LWE3MTYtNDQ2NjU1NDQwMDAw
+GET /v1/users?limit=10
+GET /v1/users?limit=10&after=NTUwZTg0MDAtZTI5Yi00MWQ0LWE3MTYtNDQ2NjU1NDQwMDAw
 ```
 
 | Parameter | Default | Range   | Description                         |
@@ -208,8 +275,8 @@ GET /users?limit=10&after=NTUwZTg0MDAtZTI5Yi00MWQ0LWE3MTYtNDQ2NjU1NDQwMDAw
 Available when the endpoint declares `pagination: offset`.
 
 ```
-GET /users?limit=25&offset=0
-GET /users?limit=25&offset=25
+GET /v1/users?limit=25&offset=0
+GET /v1/users?limit=25&offset=25
 ```
 
 | Parameter | Default | Range   | Description                         |
@@ -223,7 +290,7 @@ Return only specific fields by passing a comma-separated list to `fields`. If
 omitted, all fields are returned.
 
 ```
-GET /users?fields=name,email
+GET /v1/users?fields=name,email
 ```
 
 ```json
@@ -242,8 +309,8 @@ Request related resources with `include`. Pass a comma-separated list of
 relation names declared in the resource file's `relations` block.
 
 ```
-GET /users/550e8400-...?include=organization
-GET /users?include=organization
+GET /v1/users/550e8400-...?include=organization
+GET /v1/users?include=organization
 ```
 
 ### Cache bypass
@@ -251,7 +318,7 @@ GET /users?include=organization
 Skip the server-side cache for a single request:
 
 ```
-GET /users?nocache=1
+GET /v1/users?nocache=1
 ```
 
 ---
@@ -261,5 +328,5 @@ GET /users?nocache=1
 All query parameters can be used together:
 
 ```
-GET /users?filter[role]=admin&sort=-created_at&search=alice&limit=10&fields=name,email&include=organization
+GET /v1/users?filter[role]=admin&sort=-created_at&search=alice&limit=10&fields=name,email&include=organization
 ```

--- a/docs/auth-and-ownership.md
+++ b/docs/auth-and-ownership.md
@@ -112,7 +112,7 @@ Shaperail does not currently auto-fill `created_by` from the token.
 You need to choose one of these patterns:
 
 - send `created_by` explicitly in the create payload
-- use a hook that sets or validates it before insert
+- use a [controller]({{ '/controllers/' | relative_url }}) that sets or validates it before insert
 
 ## Practical policy for first projects
 

--- a/docs/blog-api-example.md
+++ b/docs/blog-api-example.md
@@ -18,7 +18,7 @@ you out of the docs site.
 
 ## What the example covers
 
-- public blog post reads
+- public blog post reads with versioned URLs (`/v1/posts`)
 - protected post creation and updates
 - owner-based post and comment updates through `created_by`
 - post/comment relations
@@ -91,10 +91,24 @@ endpoints:
 
 This resource demonstrates:
 
-- public read endpoints
+- public read endpoints (served at `/v1/posts` thanks to `version: 1`)
 - owner-aware updates through `created_by`
 - cursor pagination
 - soft delete on the delete route
+
+You can add business logic by creating `resources/posts.controller.rs`:
+
+```yaml
+  create:
+    method: POST
+    path: /posts
+    auth: [admin, member]
+    input: [title, slug, body, status, created_by, published_at]
+    controller:
+      before: set_created_by
+```
+
+See the [Controllers guide]({{ '/controllers/' | relative_url }}) for details.
 
 ## Comments resource
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,7 +187,12 @@ Each target has a `type` field that determines the remaining fields:
 | `job` | `name` | Enqueue a background job by name. |
 | `webhook` | `url` | POST to an external URL. |
 | `channel` | `name`, `room` (optional) | Broadcast to a WebSocket channel. `room` scopes the broadcast. |
-| `hook` | `name` | Execute a hook function. |
+| `hook` | `name` | Execute a server-side event handler function by name. |
+
+Note: the `hook` event target type in subscriber configuration is separate from
+endpoint-level business logic. For synchronous request-lifecycle logic (input
+validation, response enrichment), use `controller:` on endpoints — see
+[Controllers]({{ '/controllers/' | relative_url }}).
 
 #### `events.webhooks`
 

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -1,0 +1,298 @@
+---
+title: Controllers
+parent: Guides
+nav_order: 3
+---
+
+# Controllers
+
+Controllers let you run synchronous business logic before or after a database
+operation, within the same HTTP request. Use them for input validation,
+normalization, authorization checks, response enrichment, and computed fields.
+
+For background work that should not block the response, use
+[jobs]({{ '/background-jobs/' | relative_url }}) instead.
+
+---
+
+## Declaring controllers
+
+Add a `controller` field to any write endpoint in your resource YAML:
+
+```yaml
+resource: users
+version: 1
+
+schema:
+  id:         { type: uuid, primary: true, generated: true }
+  email:      { type: string, format: email, unique: true, required: true }
+  name:       { type: string, min: 1, max: 200, required: true }
+  role:       { type: enum, values: [admin, member, viewer], default: member }
+  org_id:     { type: uuid, ref: organizations.id, required: true }
+  created_at: { type: timestamp, generated: true }
+  updated_at: { type: timestamp, generated: true }
+
+endpoints:
+  create:
+    method: POST
+    path: /users
+    auth: [admin]
+    input: [email, name, role, org_id]
+    controller:
+      before: validate_org
+      after: enrich_response
+    events: [user.created]
+    jobs: [send_welcome_email]
+
+  update:
+    method: PATCH
+    path: /users/:id
+    auth: [admin, owner]
+    input: [name, role]
+    controller:
+      before: normalize_name
+```
+
+Each endpoint supports at most one `before` and one `after` function. Both are
+optional — you can declare just `before`, just `after`, or both.
+
+---
+
+## Writing controller functions
+
+Controller functions live in a file co-located with the resource YAML:
+
+```text
+resources/
+  users.yaml                # schema + endpoints
+  users.controller.rs       # all controller functions for users
+  orders.yaml
+  orders.controller.rs
+```
+
+Two files give you the complete picture of a resource — the YAML declares what
+exists, the controller file declares how it behaves.
+
+Each function is a named async function that takes `&mut Context`:
+
+```rust
+// resources/users.controller.rs
+use shaperail_runtime::handlers::controller::{Context, ControllerResult};
+use shaperail_core::ShaperailError;
+
+/// Called before create — normalize email and validate org exists.
+pub async fn validate_org(ctx: &mut Context) -> ControllerResult {
+    // Normalize email to lowercase
+    if let Some(email) = ctx.input.get("email").and_then(|v| v.as_str()) {
+        ctx.input["email"] = serde_json::json!(email.to_lowercase());
+    }
+
+    // Validate that org_id references a real organization
+    if let Some(org_id) = ctx.input.get("org_id").and_then(|v| v.as_str()) {
+        let exists = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS(SELECT 1 FROM organizations WHERE id = $1)"
+        )
+        .bind(org_id)
+        .fetch_one(&ctx.pool)
+        .await
+        .unwrap_or(false);
+
+        if !exists {
+            return Err(ShaperailError::Validation(vec![
+                shaperail_core::FieldError {
+                    field: "org_id".into(),
+                    message: "organization does not exist".into(),
+                    code: "invalid_reference".into(),
+                },
+            ]));
+        }
+    }
+
+    Ok(())
+}
+
+/// Called after create — add computed fields to the response.
+pub async fn enrich_response(ctx: &mut Context) -> ControllerResult {
+    if let Some(data) = &mut ctx.data {
+        data["display_name"] = serde_json::json!(
+            format!("{} ({})",
+                data["name"].as_str().unwrap_or(""),
+                data["role"].as_str().unwrap_or("member")
+            )
+        );
+    }
+    Ok(())
+}
+
+/// Called before update — normalize the name field.
+pub async fn normalize_name(ctx: &mut Context) -> ControllerResult {
+    if let Some(name) = ctx.input.get("name").and_then(|v| v.as_str()) {
+        let trimmed = name.trim().to_string();
+        ctx.input["name"] = serde_json::json!(trimmed);
+    }
+    Ok(())
+}
+```
+
+Function names in the controller file must match what is declared in the YAML.
+
+---
+
+## ControllerContext API
+
+The `Context` struct is the single type passed to all controller functions:
+
+| Field | Type | Available | Description |
+| --- | --- | --- | --- |
+| `input` | `serde_json::Map<String, Value>` | before + after | Mutable request input. Before-controllers can modify what gets written to the database. |
+| `data` | `Option<serde_json::Value>` | after only | The database result. `None` in before-controllers, `Some(...)` in after-controllers. After-controllers can modify the response. |
+| `user` | `Option<AuthenticatedUser>` | before + after | The authenticated user from the JWT or API key, if present. Contains `user_id` and `role`. |
+| `pool` | `sqlx::PgPool` | before + after | Database connection pool for running custom queries. |
+| `headers` | `HashMap<String, String>` | before + after | Read-only copy of the request headers. |
+| `response_headers` | `Vec<(String, String)>` | before + after | Push `(name, value)` pairs to add extra response headers. |
+
+---
+
+## Request lifecycle
+
+Controllers run synchronously within the request. The full handler flow is:
+
+```
+auth check
+  → extract input
+    → validate fields
+      → BEFORE controller
+        → DB operation (insert / update / delete)
+      → AFTER controller
+    → side effects (cache invalidation, events, jobs)
+  → HTTP response
+```
+
+Key behaviors:
+
+- **Before-controllers** run after validation but before the DB write. They can
+  modify `ctx.input` (e.g., normalize email, inject tenant ID) or return
+  `Err(...)` to halt the request.
+- **After-controllers** run after the DB write. They can modify `ctx.data`
+  (e.g., strip internal fields, add computed values) or add response headers.
+- If a controller returns `Err(ShaperailError::...)`, the request is aborted
+  with the corresponding error response. For before-controllers, the DB
+  operation is skipped entirely.
+
+---
+
+## ControllerMap registry
+
+Generated code populates a `ControllerMap` at startup. The map stores
+`(resource_name, function_name) → function` entries and is shared across all
+request handlers via `AppState`.
+
+```rust
+// In your generated main.rs (produced by `shaperail generate`)
+let mut controllers = ControllerMap::new();
+controllers.register("users", "validate_org", users_controller::validate_org);
+controllers.register("users", "enrich_response", users_controller::enrich_response);
+controllers.register("users", "normalize_name", users_controller::normalize_name);
+```
+
+You do not write this wiring by hand — `shaperail generate` reads the YAML
+declarations and emits the registry code.
+
+---
+
+## Common patterns
+
+### Auto-fill `created_by` from token
+
+```rust
+pub async fn set_created_by(ctx: &mut Context) -> ControllerResult {
+    if let Some(user) = &ctx.user {
+        ctx.input["created_by"] = serde_json::json!(user.user_id);
+    } else {
+        return Err(ShaperailError::Auth("No authenticated user".into()));
+    }
+    Ok(())
+}
+```
+
+### Strip internal fields from the response
+
+```rust
+pub async fn strip_internals(ctx: &mut Context) -> ControllerResult {
+    if let Some(data) = &mut ctx.data {
+        if let Some(obj) = data.as_object_mut() {
+            obj.remove("internal_score");
+            obj.remove("admin_notes");
+        }
+    }
+    Ok(())
+}
+```
+
+### Conditional logic based on role
+
+```rust
+pub async fn admin_only_fields(ctx: &mut Context) -> ControllerResult {
+    let is_admin = ctx.user.as_ref().map_or(false, |u| u.role == "admin");
+    if !is_admin {
+        ctx.input.remove("role");
+        ctx.input.remove("org_id");
+    }
+    Ok(())
+}
+```
+
+### Add custom response headers
+
+```rust
+pub async fn add_deprecation_header(ctx: &mut Context) -> ControllerResult {
+    ctx.response_headers.push((
+        "Deprecation".into(),
+        "true".into(),
+    ));
+    ctx.response_headers.push((
+        "Sunset".into(),
+        "2026-06-01".into(),
+    ));
+    Ok(())
+}
+```
+
+---
+
+## Controllers vs jobs vs events
+
+| Mechanism | When it runs | Blocks response | Use case |
+| --- | --- | --- | --- |
+| `controller` | In the request | Yes | Validation, normalization, response enrichment, auth checks |
+| `jobs` | Background (Redis queue) | No | Sending emails, generating reports, external API calls |
+| `events` | After response (async) | No | Audit logs, webhooks, WebSocket broadcasts |
+
+Use controllers for logic that must complete before the response is sent. Use
+jobs for work that can happen later. Use events to notify other systems.
+
+---
+
+## Migration from hooks
+
+In v0.2.x, the `hooks:` field enqueued functions as background jobs — identical
+to `jobs:`. In v0.3.0, `hooks:` was removed and replaced with `controller:` for
+synchronous in-request logic.
+
+If your resource files use `hooks:`, update them:
+
+```yaml
+# v0.2.x (no longer valid)
+endpoints:
+  create:
+    hooks: [validate_org]
+
+# v0.3.0
+endpoints:
+  create:
+    controller:
+      before: validate_org
+```
+
+Using the old `hooks:` field now produces a clear "unknown field" error thanks to
+`deny_unknown_fields` on all Shaperail types.

--- a/docs/events-and-webhooks.md
+++ b/docs/events-and-webhooks.md
@@ -90,7 +90,11 @@ Subscribers match events using these patterns:
 | `job`     | `name`           | Enqueues a background job by name               |
 | `webhook` | `url`            | POSTs the event payload to an external URL      |
 | `channel` | `name`, `room`   | Broadcasts to a WebSocket channel and room      |
-| `hook`    | `name`           | Executes a named hook function                  |
+| `hook`    | `name`           | Executes a named server-side event handler function |
+
+Note: the `hook` event target type runs asynchronously in response to events. It
+is separate from endpoint-level [controllers]({{ '/controllers/' | relative_url }}),
+which run synchronously within the HTTP request.
 
 ## Outbound webhooks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,6 +49,7 @@ cd my-app
 The scaffold includes:
 
 - `resources/posts.yaml` as a starter resource
+- `controllers/` directory for business logic (see [Controllers]({{ '/controllers/' | relative_url }}))
 - `migrations/` with an initial SQL migration
 - `docker-compose.yml` for Postgres and Redis
 - `.env` wired to that compose file
@@ -71,10 +72,11 @@ shaperail serve
 
 Verify the generated surfaces:
 
-- `http://localhost:3000/docs`
-- `http://localhost:3000/openapi.json`
-- `http://localhost:3000/health`
-- `http://localhost:3000/health/ready`
+- `http://localhost:3000/docs` — interactive API docs
+- `http://localhost:3000/openapi.json` — OpenAPI 3.1 spec
+- `http://localhost:3000/health` — liveness check
+- `http://localhost:3000/health/ready` — readiness (DB + Redis)
+- `http://localhost:3000/v1/posts` — your first versioned API endpoint
 
 ## Make your first change
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -15,6 +15,7 @@ Task-focused guides for building and running a Shaperail application.
 | --- | --- |
 | [**Getting started**]({{ '/getting-started/' | relative_url }}) | Install the CLI, scaffold a project, start Postgres and Redis, run the app, make your first schema change, and troubleshoot. |
 | [**Auth and ownership**]({{ '/auth-and-ownership/' | relative_url }}) | Public, role-based, and owner-based auth; JWT and API keys; rate limiting; recommended patterns for `created_by` and owner checks. |
+| [**Controllers**]({{ '/controllers/' | relative_url }}) | Synchronous business logic before/after DB operations: validation, normalization, response enrichment. ControllerContext API, file conventions, common patterns. |
 | [**Migrations and schema changes**]({{ '/migrations-and-schema-changes/' | relative_url }}) | Workflow when resources change: validate, migrate, review SQL, rollback. How `shaperail migrate` and `shaperail serve` interact. |
 | [**Docker deployment**]({{ '/docker-deployment/' | relative_url }}) | Local development with Docker Compose, standard URLs, release image with `shaperail build --docker`, production checklist. |
 | [**Caching**]({{ '/caching/' | relative_url }}) | Declaring cache on GET endpoints, cache key format, auto-invalidation, `invalidate_on`, cache bypass, Redis configuration. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ You edit these files; the framework generates the rest.
 | File | Role |
 | --- | --- |
 | `resources/*.yaml` | Schema, endpoints, auth, relations, filters, pagination, cache, indexes |
+| `resources/*.controller.rs` | Business logic functions for controllers declared in the YAML |
 | `migrations/*.sql` | SQL that evolves the database (generated from resource diff) |
 | `shaperail.config.yaml` | Port, database, cache, auth, storage, logging, event subscribers |
 | `.env` | `DATABASE_URL`, `REDIS_URL`, `JWT_SECRET`, etc. |
@@ -79,12 +80,14 @@ Generated Rust, OpenAPI, and routes live in `generated/` and are not hand-edited
 ## Features at a glance
 
 - **REST API** — List, get, create, update, delete, bulk create/delete; cursor or offset pagination; filters, sort, full-text search; field selection and relation loading (`?include=…`).
+- **API versioning** — Per-resource `version` field prefixes all routes (`/v1/users`, `/v2/orders`). OpenAPI spec and CLI output reflect versioned paths.
+- **Controllers** — Synchronous before/after business logic on write endpoints. Validate input, normalize data, enrich responses — all within the request lifecycle.
 - **Auth** — JWT (Bearer) and API keys (`X-API-Key`); role-based and owner-based rules; rate limiting via Redis.
 - **Caching** — Redis-backed cache per GET endpoint with TTL and configurable invalidation.
-- **Background jobs** — Priority queues, retries, dead letter queue, job status; enqueue from hooks.
+- **Background jobs** — Priority queues, retries, dead letter queue, job status; enqueue from endpoint declarations.
 - **WebSockets** — Channel YAML, JWT on upgrade, room subscriptions, Redis pub/sub for multi-instance broadcast.
 - **File storage** — Local, S3, GCS, Azure; upload validation, signed URLs, image processing.
-- **Events & webhooks** — Auto-emitted resource events; subscribers (job, webhook, channel, hook); outbound HMAC-signed webhooks; inbound webhook endpoints.
+- **Events & webhooks** — Auto-emitted resource events; subscribers (job, webhook, channel); outbound HMAC-signed webhooks; inbound webhook endpoints.
 - **Observability** — Structured JSON logs, request_id, PII redaction; Prometheus metrics; OpenTelemetry; `/health` and `/health/ready`.
 - **OpenAPI & SDK** — Deterministic OpenAPI 3.1; TypeScript SDK generation.
 
@@ -98,7 +101,7 @@ Generated Rust, OpenAPI, and routes live in `generated/` and are not hand-edited
 
 ### Guides
 
-- [**Guides**]({{ '/guides/' | relative_url }}) — Auth, migrations, Docker, caching, jobs, WebSockets, file storage, events, observability.
+- [**Guides**]({{ '/guides/' | relative_url }}) — Auth, controllers, migrations, Docker, caching, jobs, WebSockets, file storage, events, observability.
 
 ### Reference
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -13,7 +13,7 @@ Canonical reference for the Shaperail resource format, project configuration, CL
 
 | Page | Description |
 | --- | --- |
-| [**Resource guide**]({{ '/resource-guide/' | relative_url }}) | Resource YAML: top-level keys, schema fields, field types, endpoints, relations, indexes. The schema contract that drives codegen and runtime. |
+| [**Resource guide**]({{ '/resource-guide/' | relative_url }}) | Resource YAML: top-level keys, API versioning, schema fields, field types, endpoints, controllers, relations, indexes. The schema contract that drives codegen and runtime. |
 | [**CLI reference**]({{ '/cli-reference/' | relative_url }}) | All `shaperail` commands: init, generate, validate, migrate, seed, serve, build, export openapi/sdk, doctor, routes, jobs:status. |
 | [**Configuration reference**]({{ '/configuration/' | relative_url }}) | `shaperail.config.yaml`: project, port, workers, database, cache, auth, storage, logging, events. Environment variable interpolation. |
 | [**API responses and query parameters**]({{ '/api-responses/' | relative_url }}) | Response envelope (data/meta), error format, filtering, sorting, search, pagination (cursor/offset), field selection, relation loading, cache bypass. |

--- a/docs/resource-guide.md
+++ b/docs/resource-guide.md
@@ -66,6 +66,10 @@ endpoints:
     path: /users
     auth: [admin]
     input: [email, name, role, org_id]
+    controller:
+      before: validate_org
+    events: [user.created]
+    jobs: [send_welcome_email]
 
 relations:
   organization: { resource: organizations, type: belongs_to, key: org_id }
@@ -73,6 +77,29 @@ relations:
 indexes:
   - { fields: [org_id, role] }
 ```
+
+## API versioning
+
+The `version` field on each resource drives URL path prefixing. All endpoints
+for a resource are registered under `/v{version}/...`:
+
+```yaml
+resource: users
+version: 1    # endpoints register under /v1/users, /v1/users/{id}, etc.
+```
+
+```yaml
+resource: orders
+version: 2    # endpoints register under /v2/orders, /v2/orders/{id}, etc.
+```
+
+The version prefix appears in:
+- All HTTP routes at runtime
+- The OpenAPI spec paths
+- The output of `shaperail routes`
+
+Each resource carries its own version independently. When you scaffold a new
+project with `shaperail init`, resources default to `version: 1`.
 
 ## Schema fields
 
@@ -134,6 +161,18 @@ endpoints:
     input: [title, slug, body, status, created_by]
 ```
 
+### Supported endpoint actions
+
+| Action | Method | Typical path | Description |
+| --- | --- | --- | --- |
+| `list` | GET | `/resources` | List with pagination, filters, sort, search |
+| `get` | GET | `/resources/:id` | Fetch a single record by ID |
+| `create` | POST | `/resources` | Create a single record |
+| `update` | PATCH | `/resources/:id` | Update a single record |
+| `delete` | DELETE | `/resources/:id` | Delete (or soft-delete) a single record |
+| `bulk_create` | POST | `/resources/bulk` | Create multiple records in one request |
+| `bulk_delete` | DELETE | `/resources/bulk` | Delete multiple records by ID list |
+
 ### Endpoint attributes
 
 | Key | Meaning |
@@ -147,7 +186,7 @@ endpoints:
 | `pagination` | `cursor` (default) or `offset` |
 | `sort` | Fields available for sorting: `?sort=-created_at,name` |
 | `cache` | Cache config: `{ ttl: 60 }` or `{ ttl: 60, invalidate_on: [users.updated] }` |
-| `hooks` | Hook functions to run before/after the operation |
+| `controller` | Synchronous business logic: `{ before: fn, after: fn }`. See [Controllers]({{ '/controllers/' | relative_url }}). |
 | `events` | Events to emit on success (e.g., `[user.created]`) |
 | `jobs` | Background jobs to enqueue on success (e.g., `[send_welcome_email]`) |
 | `upload` | Multipart file upload config: `{ field: avatar, storage: s3, max_size: 5mb }` |
@@ -159,7 +198,7 @@ Important behavior:
 - `filters`, `search`, `pagination`, and `sort` only exist when declared.
 - `soft_delete: true` changes delete semantics to a `deleted_at` workflow.
   Requires an `updated_at` field in the schema.
-- Hooks, jobs, events, and cache behavior are attached per endpoint, not
+- Controllers, jobs, events, and cache behavior are attached per endpoint, not
   inferred globally.
 - Every create/update/delete automatically emits an event (`resource.action`)
   regardless of the `events` list.


### PR DESCRIPTION
## Summary

- **New controllers guide** (`controllers.md`) — full documentation for the v0.3.0 controller system: ControllerContext API, file conventions, common patterns, migration from hooks
- **API versioning documented** — explains how `version:` field prefixes all routes with `/v{N}`
- **Bulk operations documented** — request/response format for `bulk_create` and `bulk_delete` with YAML declarations
- **hooks → controller migration** across all docs — resource guide, auth guide, index, getting started, blog example, events, configuration
- **Versioned URL examples** throughout api-responses.md (all examples now show `/v1/...`)
- **Release version bumped** to 0.3.0 in `_config.yml`

### Files changed (12)
- `docs/controllers.md` (NEW) — 300-line guide
- `docs/resource-guide.md` — versioning section, endpoint actions table, controller attribute
- `docs/api-responses.md` — bulk ops docs, versioned URLs
- `docs/configuration.md` — hook target clarification
- `docs/events-and-webhooks.md` — hook target clarification
- `docs/auth-and-ownership.md` — controller reference
- `docs/index.md` — features list, what-you-author table
- `docs/getting-started.md` — versioned endpoint, controllers dir
- `docs/blog-api-example.md` — versioned URLs, controller example
- `docs/guides.md` — controllers entry in index
- `docs/reference.md` — updated resource guide description
- `docs/_config.yml` — release_version 0.3.0

## Test plan
- [ ] Verify Jekyll builds without errors
- [ ] Verify all internal links resolve (controllers, resource guide, etc.)
- [ ] Verify no stale `hooks:` references in endpoint contexts


🤖 Generated with [Claude Code](https://claude.com/claude-code)