### PR TITLE
docs: align examples index with repository examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,20 +7,30 @@ permalink: /examples/
 
 # Examples
 
-Complete examples that show how a real Shaperail application is structured.
+Examples that show how real Shaperail applications are structured. Repository
+examples link directly to the checked-in code under `examples/`, and in-guide
+walkthroughs cover patterns that are documented rather than checked into the
+repo.
 
 ## Available examples
 
 | Example | Description |
 | --- | --- |
-| [**Blog API**]({{ '/blog-api-example/' | relative_url }}) | Two resources (posts, comments) with controllers: slug generation, edit rules, comment rate limiting, XSS prevention. Public reads, protected writes, owner-based updates, relations, cursor/offset pagination, soft delete. |
-| **Incident platform** | Repository example under `examples/incident-platform/`. Single app showing API-key alert ingest, file uploads, jobs/workers, event subscribers, inbound and outbound webhooks, WebSocket rooms, GraphQL/gRPC wiring, and manual runtime bootstrap in `src/main.rs`. |
-| **Multi-service workspace** | Two services (users-api, orders-api) showing workspace layout, dependency-ordered startup, and validated saga definitions for order creation. |
-| **Multi-tenant SaaS** | Three resources (organizations, projects, tasks) with controllers: plan-based project limits, status transition enforcement, cross-resource validation, tenant-scoped uniqueness. Shows `tenant_key`, JWT tenant claims, `super_admin` bypass. |
-| **Controller walkthrough** | See the [Controllers]({{ '/controllers/' | relative_url }}) guide for a complete multi-resource billing walkthrough with manual controller registration, workflow/state-machine controllers, audit logging, payment reconciliation, and testing guidance. |
-| **WASM plugins** | Controller hooks written in TypeScript and Python compiled to WASM. Includes email validation and input normalization examples with the full plugin interface documented. |
+| [**Blog API**]({{ '/blog-api-example/' | relative_url }}) | Two resources (posts, comments) with controllers: slug generation, edit rules, comment rate limiting, XSS prevention. Public reads, protected writes, owner-based updates, relations, cursor/offset pagination, soft delete. The checked-in project lives in [examples/blog-api](https://github.com/shaperail/shaperail/tree/main/examples/blog-api). |
+| [**Enterprise SaaS**](https://github.com/shaperail/shaperail/tree/main/examples/enterprise-saas) | Billing and subscription management example with invoice workflow enforcement, payment validation, audit logs, plan-based credit limits, and tenant-scoped business rules. |
+| [**Incident platform**](https://github.com/shaperail/shaperail/tree/main/examples/incident-platform) | Single app showing API-key alert ingest, file uploads, jobs/workers, event subscribers, inbound and outbound webhooks, WebSocket rooms, GraphQL/gRPC wiring, and manual runtime bootstrap in `src/main.rs`. |
+| [**Multi-service workspace**](https://github.com/shaperail/shaperail/tree/main/examples/multi-service) | Two services (users-api, orders-api) showing workspace layout, dependency-ordered startup, and validated saga definitions for order creation. |
+| [**Multi-tenant SaaS**](https://github.com/shaperail/shaperail/tree/main/examples/multi-tenant) | Three resources (organizations, projects, tasks) with controllers: plan-based project limits, status transition enforcement, cross-resource validation, tenant-scoped uniqueness. Shows `tenant_key`, JWT tenant claims, `super_admin` bypass. |
+| [**WASM plugins**](https://github.com/shaperail/shaperail/tree/main/examples/wasm-plugins) | Controller hooks written in TypeScript and Python compiled to WASM. Includes email validation and input normalization examples with the full plugin interface documented. |
+| [**Controller walkthrough**]({{ '/controllers/' | relative_url }}) | Documentation walkthrough in the Controllers guide. Complements the repository examples with a complete multi-resource billing walkthrough focused on controller patterns and testing guidance. |
 
-Examples show real controller logic patterns in the documentation, but the
-repository examples focus on resource/config layout and HTTP flows. If you wire
-controllers into a running app today, manual controller registration is still
-required.
+The repository currently includes these example directories under `examples/`:
+[`blog-api`](https://github.com/shaperail/shaperail/tree/main/examples/blog-api),
+[`enterprise-saas`](https://github.com/shaperail/shaperail/tree/main/examples/enterprise-saas),
+[`incident-platform`](https://github.com/shaperail/shaperail/tree/main/examples/incident-platform),
+[`multi-service`](https://github.com/shaperail/shaperail/tree/main/examples/multi-service),
+[`multi-tenant`](https://github.com/shaperail/shaperail/tree/main/examples/multi-tenant),
+and [`wasm-plugins`](https://github.com/shaperail/shaperail/tree/main/examples/wasm-plugins).
+
+If you wire controllers into a running app today, manual controller
+registration is still required.

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,4 +117,4 @@ Generated Rust, OpenAPI, and routes live in `generated/` and are not hand-edited
 
 ### Examples
 
-- [**Examples**]({{ '/examples/' | relative_url }}) — [Blog API example]({{ '/blog-api-example/' | relative_url }}) plus repository examples for an incident platform, multi-tenant SaaS, multi-service workspaces, and WASM plugins.
+- [**Examples**]({{ '/examples/' | relative_url }}) — [Blog API example]({{ '/blog-api-example/' | relative_url }}) plus direct links to the checked-in repository examples for enterprise SaaS billing, an incident platform, multi-tenant SaaS, multi-service workspaces, and WASM plugins.


### PR DESCRIPTION
## Summary

- what changed
- why it changed

## Checks

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] docs updated if user-facing behavior changed
- [ ] example or reproduction added if this changes the framework contract

## Notes

- rollout or release impact
- open questions or tradeoffs
