### PR TITLE
feat: LLM-first developer experience — guide, reference, llm-context command, doc audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
             ${{ runner.os }}-cargo-${{ github.job }}-
             ${{ runner.os }}-cargo-
       - run: cargo fmt --check
-      - run: cargo clippy --workspace --all-targets -- -D warnings
-      - run: cargo bench --workspace --no-run
-      - run: cargo build --workspace
+      - run: cargo clippy --locked --workspace --all-targets -- -D warnings
+      - run: cargo bench --locked --workspace --no-run
+      - run: cargo build --locked --workspace
 
   test:
     name: Tests
@@ -84,7 +84,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ github.job }}-
             ${{ runner.os }}-cargo-
-      - run: cargo test --workspace
+      - run: cargo test --locked --workspace
 
   audit:
     name: Security Audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9698bf0769c641b18618039fe2ebd41eb3541f98433000f64e663fab7cea2c87"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -390,9 +390,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -411,9 +411,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -510,7 +510,7 @@ dependencies = [
  "fnv",
  "futures-util",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap",
  "mime",
  "multer",
  "num-traits",
@@ -579,7 +579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
 dependencies = [
  "bytes",
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_json",
 ]
@@ -668,11 +668,10 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -685,8 +684,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "sync_wrapper",
  "tower 0.5.3",
  "tower-layer",
@@ -695,19 +693,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -785,15 +781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,7 +813,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hex",
- "indexmap 2.13.0",
+ "indexmap",
  "js-sys",
  "once_cell",
  "rand 0.9.2",
@@ -931,7 +918,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -977,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -987,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -999,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1076,12 +1063,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1451,15 +1432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,7 +1440,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1607,7 +1579,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1692,21 +1664,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1754,7 +1715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1780,7 +1741,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -1802,7 +1763,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -2171,7 +2132,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2194,7 +2155,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -2221,7 +2182,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2240,7 +2201,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2257,12 +2218,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2376,7 +2331,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2451,15 +2406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,7 +2475,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2689,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.10"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -2720,16 +2666,6 @@ name = "impl-more"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -2883,7 +2819,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "signature",
  "simple_asn1",
 ]
@@ -3062,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -3073,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3186,7 +3122,7 @@ dependencies = [
  "serde_bytes",
  "serde_with",
  "sha1",
- "sha2 0.10.9",
+ "sha2",
  "socket2 0.6.2",
  "stringprep",
  "strsim",
@@ -3214,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.8.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -3334,7 +3270,7 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "memchr",
 ]
 
@@ -3362,7 +3298,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest",
  "ring",
  "rustls-pki-types",
@@ -3422,18 +3358,18 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.14.5",
+ "tonic",
 ]
 
 [[package]]
@@ -3444,8 +3380,8 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
- "tonic 0.14.5",
+ "prost",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -3508,7 +3444,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3520,7 +3456,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3574,7 +3510,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3619,7 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -3889,35 +3825,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3927,7 +3840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3939,7 +3852,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -4000,7 +3913,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4037,9 +3950,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4092,13 +4005,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4141,9 +4054,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -4353,8 +4266,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
+ "const-oid",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -4461,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4683,7 +4596,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4749,7 +4662,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4764,7 +4677,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4781,18 +4694,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest",
 ]
 
 [[package]]
@@ -4803,7 +4705,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "deadpool-redis",
- "indexmap 2.13.0",
+ "indexmap",
  "predicates",
  "redis",
  "serde",
@@ -4821,7 +4723,7 @@ dependencies = [
 name = "shaperail-codegen"
 version = "0.7.0"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "insta",
  "serde",
  "serde_json",
@@ -4837,7 +4739,7 @@ version = "0.7.0"
 dependencies = [
  "actix-web",
  "chrono",
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_json",
  "sqlx",
@@ -4867,7 +4769,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "image",
- "indexmap 2.13.0",
+ "indexmap",
  "jsonwebtoken",
  "mongodb",
  "object_store",
@@ -4875,7 +4777,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prometheus",
- "prost 0.13.5",
+ "prost",
  "prost-types",
  "redis",
  "sea-orm",
@@ -4883,14 +4785,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.11.0",
+ "sha2",
  "shaperail-core",
  "sqlx",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.12.3",
+ "tonic",
  "tonic-health",
  "tonic-reflection",
  "tower 0.4.13",
@@ -4933,7 +4835,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -5057,7 +4959,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -5065,7 +4967,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5104,7 +5006,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5127,7 +5029,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5148,7 +5050,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5187,7 +5089,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5569,7 +5471,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5602,7 +5504,7 @@ version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -5625,11 +5527,10 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64",
@@ -5643,33 +5544,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
+ "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -5685,10 +5560,10 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -5699,8 +5574,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.5",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -5709,11 +5584,11 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -5723,18 +5598,8 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5745,7 +5610,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5858,9 +5723,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -6152,7 +6017,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "im-rc",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "petgraph",
  "serde",
@@ -6191,7 +6056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -6217,7 +6082,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "semver",
  "serde",
 ]
@@ -6229,7 +6094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap",
  "semver",
 ]
 
@@ -6309,7 +6174,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "object",
  "postcard",
@@ -6339,7 +6204,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
- "sha2 0.10.9",
+ "sha2",
  "toml",
  "wasmtime-environ",
  "windows-sys 0.61.2",
@@ -6493,7 +6358,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap",
  "wit-parser",
 ]
 
@@ -6966,7 +6831,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -6997,7 +6862,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -7016,7 +6881,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ async-graphql = { version = "7", default-features = false, features = ["chrono",
 async-graphql-actix-web = { version = "7", default-features = false }
 
 # gRPC (M16)
-tonic = { version = "0.12", default-features = false, features = ["transport", "codegen", "prost"] }
-prost = "0.13"
+tonic = { version = "0.14", default-features = false, features = ["transport", "router"] }
+prost = "0.14"
 prost-types = "0.14"
 tonic-reflection = "0.14"
 tonic-health = "0.14"

--- a/agent_docs/milestones.md
+++ b/agent_docs/milestones.md
@@ -47,7 +47,7 @@ Example: `/milestone 1` builds Core Types. `/milestone 14` builds Multi-DB suppo
 **Deliverables:**
 - [x] `parser` module: YAML string → `ResourceDefinition` (exact PRD format: `resource:` key, inline fields)
 - [x] `config_parser` module: shaperail.config.yaml → `ProjectConfig`
-- [x] `validator` module: semantic checks — enum needs values, soft_delete needs updated_at, ref field must be uuid type, hooks list must be strings
+- [x] `validator` module: semantic checks — enum needs values, soft_delete needs deleted_at, ref field must be uuid type, hooks list must be strings
 - [x] Error messages in format: `"resource 'users': field 'role' is type enum but has no values"`
 - [x] `shaperail validate <file>` CLI subcommand: reads resource file, prints errors or "✓ valid"
 - [x] Snapshot tests (insta): 5 valid resources → snapshot parsed output; 10 invalid → snapshot error messages

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -92,6 +92,7 @@ schema:
   last_name:    { type: string, min: 1, max: 100, required: true }
   display_name: { type: string, max: 200 }
   role:         { type: enum, values: [admin, member, viewer], default: member }
+  deleted_at:   { type: timestamp, nullable: true }
   created_at:   { type: timestamp, generated: true }
   updated_at:   { type: timestamp, generated: true }
 

--- a/docs/blog-api-example.md
+++ b/docs/blog-api-example.md
@@ -63,6 +63,7 @@ schema:
   status:       { type: enum, values: [draft, published, archived], default: draft }
   created_by:   { type: uuid, required: true }
   published_at: { type: timestamp, nullable: true }
+  deleted_at:   { type: timestamp, nullable: true }
   created_at:   { type: timestamp, generated: true }
   updated_at:   { type: timestamp, generated: true }
 

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -1163,6 +1163,7 @@ schema:
   status:             { type: enum, values: [active, suspended, closed], default: active }
   credit_limit_cents: { type: bigint, default: 0 }
   created_by:         { type: uuid, required: true }
+  deleted_at:         { type: timestamp, nullable: true }
   created_at:         { type: timestamp, generated: true }
   updated_at:         { type: timestamp, generated: true }
 
@@ -1218,6 +1219,7 @@ schema:
   sent_at:        { type: timestamp, nullable: true }
   paid_at:        { type: timestamp, nullable: true }
   created_by:     { type: uuid, required: true }
+  deleted_at:     { type: timestamp, nullable: true }
   created_at:     { type: timestamp, generated: true }
   updated_at:     { type: timestamp, generated: true }
 

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -1,0 +1,358 @@
+# Shaperail LLM Guide
+
+Load this file as your sole context. You do not need other docs to build in Shaperail.
+
+---
+
+## 1. Resource File Structure
+
+Every resource is a YAML file at `resources/<name>.yaml`.
+
+```yaml
+resource: <name>      # snake_case plural noun (required)
+version: <int>        # >= 1 — sets route prefix /v{n}/... (required)
+db: <db_name>         # named DB from config.databases (optional)
+tenant_key: <field>   # schema field name for row-level tenant isolation (optional)
+schema: ...           # map of field definitions (required, must include a primary key)
+endpoints: ...        # map of endpoint definitions (optional)
+relations: ...        # map of relation definitions (optional)
+indexes: ...          # list of index definitions (optional)
+```
+
+---
+
+## 2. Field Types
+
+| Type      | Requires        | Valid Options                                                         |
+|-----------|-----------------|-----------------------------------------------------------------------|
+| uuid      |                 | primary, generated, required, unique, ref, sensitive                  |
+| string    |                 | required, unique, min, max, format, sensitive                         |
+| integer   |                 | required, unique, min, max, default                                   |
+| float     |                 | required, min, max, default                                           |
+| boolean   |                 | required, default                                                     |
+| timestamp |                 | generated, required, nullable                                         |
+| enum      | values          | values (required), default, required                                  |
+| json      |                 | required, nullable                                                    |
+| array     | items           | items (required — e.g. `items: string`), required                    |
+
+`format` valid values: `email`, `url`, `slug`, `phone` (string fields only).
+`ref` format: `resource_name.field_name` — the field must be `type: uuid`.
+
+---
+
+## 3. Field Options Reference
+
+| Option    | Type    | Applies to           | Effect                                                          |
+|-----------|---------|----------------------|-----------------------------------------------------------------|
+| primary   | bool    | uuid                 | Marks as primary key                                            |
+| generated | bool    | uuid, timestamp      | Auto-generated (UUID v7 / NOW()) — do not include in input     |
+| required  | bool    | any                  | NOT NULL in DB, required in create/update input                 |
+| unique    | bool    | any                  | UNIQUE constraint                                               |
+| nullable  | bool    | timestamp, json      | Allows null — overrides `required`                              |
+| min       | number  | string, int, float   | Min length (string) or minimum value (numbers)                  |
+| max       | number  | string, int, float   | Max length (string) or maximum value (numbers)                  |
+| format    | string  | string only          | Validation format: email / url / slug / phone                   |
+| values    | list    | enum only            | Allowed enum values — required when `type: enum`                |
+| default   | any     | enum, bool, int      | Default value. For enum must be one of `values`                 |
+| ref       | string  | uuid only            | Foreign key reference in `resource.field` format                |
+| items     | string  | array only           | Element type — required when `type: array`                      |
+| sensitive | bool    | uuid, string         | Redacted in logs, omitted from list responses                   |
+
+---
+
+## 4. Endpoints
+
+### Convention-based (method + path inferred from action name)
+
+| Action | Method | Path               |
+|--------|--------|--------------------|
+| list   | GET    | /v{n}/{resource}   |
+| create | POST   | /v{n}/{resource}   |
+| get    | GET    | /v{n}/{resource}/{id} |
+| update | PATCH  | /v{n}/{resource}/{id} |
+| delete | DELETE | /v{n}/{resource}/{id} |
+
+For custom endpoints, provide `method:` and `path:` explicitly.
+
+### Valid Keys per Endpoint Type
+
+| Key         | list | create | get | update | delete | custom |
+|-------------|:----:|:------:|:---:|:------:|:------:|:------:|
+| auth        | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| input       |      | ✓      |     | ✓      |        | ✓      |
+| filters     | ✓    |        |     |        |        |        |
+| search      | ✓    |        |     |        |        |        |
+| sort        | ✓    |        |     |        |        |        |
+| pagination  | ✓    |        |     |        |        |        |
+| cache       | ✓    | ✓      | ✓   |        |        | ✓      |
+| controller  | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| events      |      | ✓      |     | ✓      | ✓      |        |
+| jobs        |      | ✓      |     | ✓      | ✓      |        |
+| soft_delete |      |        |     |        | ✓      |        |
+| upload      |      | ✓      |     |        |        |        |
+| method      |      |        |     |        |        | ✓      |
+| path        |      |        |     |        |        | ✓      |
+
+Key details:
+- `auth`: list of role names from your auth config, or `owner` (matches record creator)
+- `pagination`: `cursor` (default) or `offset` — no other values
+- `cache`: `{ ttl: <seconds> }`
+- `controller`: `{ before: <fn_name> }` and/or `{ after: <fn_name> }` — fn in `resources/<name>.controller.rs`
+- `input`: list of field names from `schema:` — not field definitions
+- `sort`: list of field names that clients can sort by
+- `filters`: list of field names that clients can filter on
+- `search`: list of string/text field names for full-text search
+
+---
+
+## 5. Controller Pattern
+
+Reference a controller in an endpoint:
+
+```yaml
+endpoints:
+  create:
+    auth: [admin]
+    input: [email, name, org_id]
+    controller: { before: validate_org }
+```
+
+The function lives in `resources/<resource_name>.controller.rs` (same directory as the YAML):
+
+```rust
+// resources/users.controller.rs
+use shaperail_runtime::ControllerContext;
+
+// before hook — return Err("message") to abort with HTTP 422
+pub async fn validate_org(ctx: &mut ControllerContext) -> Result<(), String> {
+    let org_id = ctx.input["org_id"].as_str().ok_or("org_id required")?;
+    if org_id.is_empty() {
+        return Err("org_id must not be empty".into());
+    }
+    Ok(())
+}
+
+// after hook — ctx.output has the created/updated record
+pub async fn notify_team(ctx: &ControllerContext) -> Result<(), String> {
+    let _id = &ctx.output["id"];
+    // fire side effects here
+    Ok(())
+}
+```
+
+`ControllerContext` fields:
+| Field       | Type                  | Available in   | Description                                   |
+|-------------|-----------------------|----------------|-----------------------------------------------|
+| input       | serde_json::Value     | before + after | Request body (before) / saved record (after)  |
+| output      | serde_json::Value     | after only     | The record returned by the operation          |
+| user_id     | Option<uuid::Uuid>    | before + after | Authenticated user, None if no auth           |
+| tenant_id   | Option<uuid::Uuid>    | before + after | Current tenant, None if no multi-tenancy      |
+| resource    | &str                  | before + after | Resource name (e.g., "users")                 |
+
+---
+
+## 6. Relations
+
+```yaml
+relations:
+  # belongs_to — this resource holds the foreign key
+  org:     { resource: organizations, type: belongs_to, key: org_id }
+
+  # has_many — the other resource holds the foreign key
+  posts:   { resource: posts, type: has_many, foreign_key: author_id }
+
+  # has_one — same as has_many but returns a single record
+  profile: { resource: profiles, type: has_one, foreign_key: user_id }
+```
+
+Rules:
+- `belongs_to` requires `key:` — the FK field name **on this resource's schema**
+- `has_many` / `has_one` require `foreign_key:` — the FK field name **on the related resource**
+- `resource:` must exactly match the `resource:` name in the related YAML file
+- Relations do NOT auto-create schema fields — declare the FK field in `schema:` explicitly
+
+---
+
+## 7. Indexes
+
+```yaml
+indexes:
+  - fields: [org_id, role]           # composite index
+  - fields: [email], unique: true    # unique constraint index
+  - fields: [created_at], order: desc # descending order index
+```
+
+- `fields`: list of field names from `schema:` (min 1)
+- `unique`: bool (optional, default false)
+- `order`: `asc` or `desc` (optional, default asc)
+
+---
+
+## 8. Do's and Don'ts
+
+| Rule                        | Correct                                              | Wrong                                     |
+|-----------------------------|------------------------------------------------------|-------------------------------------------|
+| Top-level key               | `resource: users`                                    | `name: users`                             |
+| Enum field                  | `{ type: enum, values: [admin, member] }`            | `{ type: enum }`                          |
+| Array field                 | `{ type: array, items: string }`                     | `{ type: array }`                         |
+| Soft delete schema          | `deleted_at: { type: timestamp, nullable: true }` + `soft_delete: true` on delete endpoint | `soft_delete: true` alone |
+| Foreign key reference       | `ref: organizations.id`                              | `ref: organizations`                      |
+| FK field type               | `{ type: uuid, ref: organizations.id }`              | `{ type: string, ref: organizations.id }` |
+| Pagination value            | `pagination: cursor` or `pagination: offset`         | `pagination: page`                        |
+| Input format                | `input: [email, name, role]`                         | `input: { email: ..., name: ... }`        |
+| Tenant key field            | `tenant_key: org_id` + `org_id: { type: uuid, required: true }` in schema | `tenant_key: org_id` without schema field |
+| Controller reference        | `controller: { before: validate_org }`               | `controller: { before: validate_org.rs }` |
+| Relation FK on belongs_to   | `{ type: belongs_to, key: org_id }`                  | `{ type: belongs_to, foreign_key: org_id }` |
+| Relation FK on has_many     | `{ type: has_many, foreign_key: user_id }`           | `{ type: has_many, key: user_id }`        |
+
+---
+
+## 9. Common Patterns
+
+### Basic CRUD Resource
+```yaml
+resource: products
+version: 1
+schema:
+  id:          { type: uuid, primary: true, generated: true }
+  name:        { type: string, min: 1, max: 200, required: true }
+  price:       { type: float, min: 0, required: true }
+  active:      { type: boolean, default: true }
+  created_at:  { type: timestamp, generated: true }
+  updated_at:  { type: timestamp, generated: true }
+endpoints:
+  list:   { auth: [member, admin] }
+  get:    { auth: [member, admin] }
+  create: { auth: [admin], input: [name, price, active] }
+  update: { auth: [admin], input: [name, price, active] }
+  delete: { auth: [admin] }
+```
+
+### User Resource with Auth + Roles
+```yaml
+resource: users
+version: 1
+schema:
+  id:         { type: uuid, primary: true, generated: true }
+  email:      { type: string, format: email, unique: true, required: true }
+  name:       { type: string, min: 1, max: 200, required: true }
+  role:       { type: enum, values: [admin, member], default: member }
+  org_id:     { type: uuid, ref: organizations.id, required: true }
+  created_at: { type: timestamp, generated: true }
+  updated_at: { type: timestamp, generated: true }
+endpoints:
+  list:   { auth: [admin], filters: [role, org_id], search: [name, email] }
+  get:    { auth: [admin, owner] }
+  create: { auth: [admin], input: [email, name, role, org_id] }
+  update: { auth: [admin, owner], input: [name, role] }
+  delete: { auth: [admin] }
+relations:
+  organization: { resource: organizations, type: belongs_to, key: org_id }
+```
+
+### Soft Delete
+```yaml
+schema:
+  ...
+  deleted_at: { type: timestamp, nullable: true }
+endpoints:
+  delete: { auth: [admin], soft_delete: true }
+```
+
+### Multi-Tenant Resource
+```yaml
+resource: projects
+version: 1
+tenant_key: org_id
+schema:
+  id:     { type: uuid, primary: true, generated: true }
+  org_id: { type: uuid, ref: organizations.id, required: true }
+  name:   { type: string, required: true }
+endpoints:
+  list:   { auth: [member, admin] }
+  create: { auth: [admin], input: [name] }
+```
+
+### List with Caching + Filtering + Cursor Pagination
+```yaml
+endpoints:
+  list:
+    auth: [member, admin]
+    filters: [status, category_id]
+    search: [title, description]
+    sort: [created_at, title]
+    pagination: cursor
+    cache: { ttl: 30 }
+```
+
+### Create with Controller + Events + Jobs
+```yaml
+endpoints:
+  create:
+    auth: [admin]
+    input: [email, name, role]
+    controller: { before: validate_email, after: send_notifications }
+    events: [user.created]
+    jobs: [send_welcome_email]
+```
+
+---
+
+## 10. Error Code Quick Reference
+
+Run `shaperail check --json` to get structured errors with fix suggestions.
+
+| Code  | Trigger                                | Fix                                                             |
+|-------|----------------------------------------|-----------------------------------------------------------------|
+| SR001 | resource name empty                    | Add `resource: <name>` (snake_case plural)                      |
+| SR002 | version is 0 or missing                | Set `version: 1`                                                |
+| SR003 | schema has no fields                   | Add at least one field                                          |
+| SR004 | no primary key                         | Add `primary: true` to one field (typically `id`)               |
+| SR005 | multiple primary keys                  | Remove `primary: true` from all but one field                   |
+| SR010 | enum field missing values              | Add `values: [a, b, c]` to the field                            |
+| SR011 | non-enum field has values              | Change `type: enum` or remove `values:`                         |
+| SR012 | ref on non-uuid field                  | Change field type to `uuid`                                     |
+| SR013 | ref not in resource.field format       | Use `ref: resource_name.field_name` (e.g., `organizations.id`)  |
+| SR014 | array field missing items              | Add `items: string` (or other type)                             |
+| SR015 | format on non-string field             | Remove `format:` or change type to `string`                     |
+| SR016 | primary key not generated              | Add `generated: true` and `required: true` to the pk field      |
+| SR020 | tenant_key field not in schema         | Add the field to `schema:`                                       |
+| SR021 | tenant_key field not uuid+required     | Set field to `{ type: uuid, required: true }`                   |
+| SR030 | controller path not found              | Path is relative to resources/, no `.rs` extension              |
+| SR031 | controller before function not found   | Check function name matches in `.controller.rs`                 |
+| SR032 | controller after function not found    | Check function name matches in `.controller.rs`                 |
+| SR033 | WASM controller path invalid           | Use `wasm:path/to/plugin.wasm` prefix                           |
+| SR035 | events on unsupported endpoint type    | Remove `events:` — only valid on create/update/delete           |
+| SR036 | jobs on unsupported endpoint type      | Remove `jobs:` — only valid on create/update/delete             |
+| SR040 | input/filter/search/sort field missing | Add field to `schema:` or fix the field name                    |
+| SR041 | soft_delete without deleted_at         | Add `deleted_at: { type: timestamp, nullable: true }` to schema |
+| SR050 | upload on non-create endpoint          | Move `upload:` to a create endpoint                             |
+| SR051 | upload missing field name              | Add `field: <name>` to upload config                            |
+| SR052 | upload field not in schema             | Add the upload field to `schema:`                               |
+| SR053 | upload field wrong type                | Change field type to `string`                                   |
+| SR054 | upload missing max_size_mb             | Add `max_size_mb: 10` to upload config                          |
+| SR060 | relation missing resource name         | Add `resource: <name>` to relation                              |
+| SR061 | belongs_to missing key                 | Add `key: <field_name>` (FK field on this resource)             |
+| SR062 | has_many/has_one missing foreign_key   | Add `foreign_key: <field_name>` (FK on the related resource)    |
+| SR070 | index has no fields                    | Add at least one field name to `fields:`                        |
+| SR071 | index field not in schema              | Fix field name to match a `schema:` field                       |
+| SR072 | index order invalid                    | Use `order: asc` or `order: desc`                               |
+
+---
+
+## 11. CLI Reference
+
+```bash
+shaperail init <name>                   # scaffold new project
+shaperail serve                         # start dev server (hot reload)
+shaperail generate                      # run codegen for all resources
+shaperail check [path] [--json]         # validate with structured fix suggestions
+shaperail explain <file>                # dry-run: show routes, table, relations
+shaperail diff                          # show what codegen would change
+shaperail llm-context [--resource <n>] [--json]  # dump project context for LLM
+shaperail migrate                       # apply pending SQL migrations
+shaperail routes                        # list all routes with auth requirements
+shaperail export openapi                # output OpenAPI 3.1 spec
+shaperail export json-schema            # output JSON Schema for resource YAML
+shaperail resource create <name> [--archetype basic|user|content|tenant|lookup]
+```

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -2,6 +2,8 @@
 
 Load this file as your sole context. You do not need other docs to build in Shaperail.
 
+**IDE validation:** Add `# yaml-language-server: $schema=https://shaperail.dev/schema/resource.schema.json` as the first line of any resource YAML file for inline validation.
+
 ---
 
 ## 1. Resource File Structure

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -37,7 +37,7 @@ indexes: ...          # list of index definitions (optional)
 | json      |                 | required, nullable                                                    |
 | array     | items           | items (required — e.g. `items: string`), required                    |
 
-`format` valid values: `email`, `url`, `slug`, `phone` (string fields only).
+`format` valid values: `email`, `url`, `uuid` (string fields only).
 `ref` format: `resource_name.field_name` — the field must be `type: uuid`.
 
 ---
@@ -53,7 +53,7 @@ indexes: ...          # list of index definitions (optional)
 | nullable  | bool    | timestamp, json      | Allows null — overrides `required`                              |
 | min       | number  | string, int, float   | Min length (string) or minimum value (numbers)                  |
 | max       | number  | string, int, float   | Max length (string) or maximum value (numbers)                  |
-| format    | string  | string only          | Validation format: email / url / slug / phone                   |
+| format    | string  | string only          | Validation format: email / url / uuid                           |
 | values    | list    | enum only            | Allowed enum values — required when `type: enum`                |
 | default   | any     | enum, bool, int      | Default value. For enum must be one of `values`                 |
 | ref       | string  | uuid only            | Foreign key reference in `resource.field` format                |

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -1,0 +1,119 @@
+# Shaperail Quick Reference
+
+Terse lookup tables. For patterns and examples, see [llm-guide.md](llm-guide.md).
+
+---
+
+## Field Types
+
+| Type      | Required sub-keys | Notes                                       |
+|-----------|------------------|---------------------------------------------|
+| uuid      | —                | Use for PKs and FKs                         |
+| string    | —                | Supports format, min, max                   |
+| integer   | —                | Supports min, max, default                  |
+| float     | —                | Supports min, max, default                  |
+| boolean   | —                | Supports default                            |
+| timestamp | —                | Use generated:true for auto-timestamps      |
+| enum      | values           | values is required                          |
+| json      | —                | Unstructured JSON blob                      |
+| array     | items            | items type is required                      |
+
+## Endpoint Keys by Type
+
+| Key         | list | create | get | update | delete | custom |
+|-------------|:----:|:------:|:---:|:------:|:------:|:------:|
+| auth        | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| input       |      | ✓      |     | ✓      |        | ✓      |
+| filters     | ✓    |        |     |        |        |        |
+| search      | ✓    |        |     |        |        |        |
+| sort        | ✓    |        |     |        |        |        |
+| pagination  | ✓    |        |     |        |        |        |
+| cache       | ✓    | ✓      | ✓   |        |        | ✓      |
+| controller  | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| events      |      | ✓      |     | ✓      | ✓      |        |
+| jobs        |      | ✓      |     | ✓      | ✓      |        |
+| soft_delete |      |        |     |        | ✓      |        |
+| upload      |      | ✓      |     |        |        |        |
+| method      |      |        |     |        |        | ✓      |
+| path        |      |        |     |        |        | ✓      |
+
+## Relation Types
+
+| Type       | Required key | Description                                    |
+|------------|-------------|------------------------------------------------|
+| belongs_to | key         | FK is on **this** resource                      |
+| has_many   | foreign_key | FK is on the **other** resource, returns list   |
+| has_one    | foreign_key | FK is on the **other** resource, returns one    |
+
+## Config Keys (`shaperail.config.yaml`)
+
+| Key        | Required | Description                                    |
+|------------|----------|------------------------------------------------|
+| project    | ✓        | Project name string                            |
+| port       |          | HTTP port (default 3000)                       |
+| workers    |          | `auto` or integer                              |
+| database   |          | Single DB: `type`, `host`, `port`, `name`      |
+| databases  |          | Multi-DB map: `engine` (postgres/mysql/sqlite/mongodb), `url` |
+| cache      |          | Redis: `url`                                   |
+| auth       |          | `provider: jwt`, `secret_env: JWT_SECRET`      |
+| storage    |          | `provider: s3/gcs/azure/local`, `bucket`       |
+| logging    |          | `level`, `format: json/text`                   |
+| events     |          | `backend: redis`                               |
+| protocols  |          | List: `[rest, graphql, grpc]`                  |
+
+## CLI Commands
+
+| Command                               | Description                                           |
+|---------------------------------------|-------------------------------------------------------|
+| `shaperail init <name>`               | Scaffold new project                                  |
+| `shaperail serve [--port N]`          | Start dev server with hot reload                      |
+| `shaperail generate`                  | Run codegen for all resources                         |
+| `shaperail check [path] [--json]`     | Validate with structured fix suggestions              |
+| `shaperail explain <file>`            | Show routes, table schema, relations                  |
+| `shaperail diff`                      | Show codegen changes (dry run)                        |
+| `shaperail llm-context [--resource N] [--json]` | Dump project context for LLM           |
+| `shaperail migrate [--rollback]`      | Apply or rollback SQL migrations                      |
+| `shaperail seed [path]`               | Load fixture YAML into database                       |
+| `shaperail routes`                    | List routes with auth requirements                    |
+| `shaperail export openapi`            | Output OpenAPI 3.1 spec                               |
+| `shaperail export sdk --lang ts`      | Generate TypeScript SDK                               |
+| `shaperail export json-schema`        | Output JSON Schema for resource YAML                  |
+| `shaperail resource create <name> [--archetype basic\|user\|content\|tenant\|lookup]` | Scaffold resource |
+| `shaperail doctor`                    | Check system dependencies                             |
+
+## Archetypes
+
+| Archetype | Fields included                                                 |
+|-----------|-----------------------------------------------------------------|
+| basic     | id, created_at, updated_at                                      |
+| user      | id, email, name, role, password_hash, created_at, updated_at   |
+| content   | id, title, body, status, author_id, created_at, updated_at     |
+| tenant    | id, name, plan, created_at, updated_at (+ tenant isolation)    |
+| lookup    | id, code, label, active, sort_order                            |
+
+## Error Codes
+
+| Code  | Trigger                              | Fix                                            |
+|-------|--------------------------------------|------------------------------------------------|
+| SR001 | Empty resource name                  | Add `resource: <name>`                         |
+| SR002 | Version < 1                          | Set `version: 1`                               |
+| SR003 | Empty schema                         | Add at least one field                         |
+| SR004 | No primary key                       | Add `primary: true` to one field               |
+| SR005 | Multiple primary keys                | Remove `primary: true` from extras             |
+| SR010 | Enum missing values                  | Add `values: [a, b]`                           |
+| SR011 | Values on non-enum                   | Change type to `enum` or remove `values:`      |
+| SR012 | ref on non-uuid field                | Change type to `uuid`                          |
+| SR013 | ref wrong format                     | Use `ref: resource.field`                      |
+| SR014 | Array missing items                  | Add `items: string`                            |
+| SR015 | format on non-string                 | Remove or change type to `string`              |
+| SR016 | PK not generated                     | Add `generated: true, required: true`          |
+| SR020 | tenant_key field absent              | Add field to `schema:`                         |
+| SR021 | tenant_key field wrong type          | Set `{ type: uuid, required: true }`           |
+| SR040 | input/filter/search/sort field absent | Add to `schema:` or fix name                  |
+| SR041 | soft_delete without deleted_at       | Add `deleted_at: { type: timestamp, nullable: true }` |
+| SR060 | Relation missing resource            | Add `resource: <name>`                         |
+| SR061 | belongs_to missing key               | Add `key: <field>`                             |
+| SR062 | has_many/has_one missing foreign_key | Add `foreign_key: <field>`                     |
+| SR070 | Index fields empty                   | Add at least one field                         |
+| SR071 | Index field not in schema            | Fix field name                                 |
+| SR072 | Index order invalid                  | Use `asc` or `desc`                            |

--- a/docs/resource-guide.md
+++ b/docs/resource-guide.md
@@ -186,10 +186,7 @@ Shaperail infers them from the resource name:
 For any **custom** endpoint name (e.g. `bulk_create`, `archive`), `method` and
 `path` are **required** — the parser cannot guess them.
 
-You can still specify `method` and `path` explicitly on standard actions if you
-want to override the convention (e.g. using PUT instead of PATCH for `update`).
-
-Minimal example using convention defaults:
+Example:
 
 ```yaml
 endpoints:
@@ -201,26 +198,6 @@ endpoints:
     sort: [created_at, title]
 
   create:
-    auth: [admin, member]
-    input: [title, slug, body, status, created_by]
-```
-
-Equivalent explicit form (still valid):
-
-```yaml
-endpoints:
-  list:
-    method: GET
-    path: /posts
-    auth: public
-    filters: [status, created_by]
-    search: [title, body]
-    pagination: cursor
-    sort: [created_at, title]
-
-  create:
-    method: POST
-    path: /posts
     auth: [admin, member]
     input: [title, slug, body, status, created_by]
 ```
@@ -261,7 +238,7 @@ Important behavior:
 - `input` controls which fields are accepted for writes.
 - `filters`, `search`, `pagination`, and `sort` only exist when declared.
 - `soft_delete: true` changes delete semantics to a `deleted_at` workflow.
-  Requires an `updated_at` field in the schema.
+  Requires `deleted_at: { type: timestamp, nullable: true }` in the schema.
 - Controllers, jobs, events, and cache behavior are attached per endpoint, not
   inferred globally.
 - Every create/update/delete automatically emits an event (`resource.action`)

--- a/docs/schema/resource.schema.json
+++ b/docs/schema/resource.schema.json
@@ -291,10 +291,6 @@
     "EndpointSpec": {
       "type": "object",
       "description": "Specification for a single endpoint in a resource.",
-      "required": [
-        "method",
-        "path"
-      ],
       "additionalProperties": false,
       "properties": {
         "method": {
@@ -365,7 +361,7 @@
         "soft_delete": {
           "type": "boolean",
           "default": false,
-          "description": "Whether this endpoint performs a soft delete. Requires an 'updated_at' field in schema."
+          "description": "Whether this endpoint performs a soft delete. Requires a 'deleted_at' nullable timestamp field in schema."
         }
       }
     },

--- a/docs/schema/resource.schema.json
+++ b/docs/schema/resource.schema.json
@@ -1,0 +1,438 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shaperail.dev/schema/resource.v1.json",
+  "title": "Shaperail Resource Definition",
+  "description": "Schema for Shaperail resource YAML files. Defines a single API resource with its fields, endpoints, relations, and indexes.",
+  "type": "object",
+  "required": [
+    "resource",
+    "version",
+    "schema"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "resource": {
+      "type": "string",
+      "description": "Snake_case plural name of the resource (e.g., 'users', 'blog_posts').",
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "version": {
+      "type": "integer",
+      "description": "Schema version number (starts at 1). Drives route prefix: /v{version}/...",
+      "minimum": 1
+    },
+    "db": {
+      "type": "string",
+      "description": "Named database connection for this resource (M14 multi-DB). Default: 'default'."
+    },
+    "tenant_key": {
+      "type": "string",
+      "description": "Tenant isolation key (M18). References a uuid schema field that identifies the tenant. When set, all queries are automatically scoped to the authenticated user's tenant_id claim."
+    },
+    "schema": {
+      "type": "object",
+      "description": "Field definitions keyed by field name. At least one field with primary: true is required.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/FieldSchema"
+      }
+    },
+    "endpoints": {
+      "type": "object",
+      "description": "Endpoint definitions keyed by action name (e.g., 'list', 'get', 'create', 'update', 'delete').",
+      "additionalProperties": {
+        "$ref": "#/$defs/EndpointSpec"
+      }
+    },
+    "relations": {
+      "type": "object",
+      "description": "Relationship definitions keyed by relation name.",
+      "additionalProperties": {
+        "$ref": "#/$defs/RelationSpec"
+      }
+    },
+    "indexes": {
+      "type": "array",
+      "description": "Additional database indexes.",
+      "items": {
+        "$ref": "#/$defs/IndexSpec"
+      }
+    }
+  },
+  "$defs": {
+    "FieldType": {
+      "type": "string",
+      "enum": [
+        "uuid",
+        "string",
+        "integer",
+        "bigint",
+        "number",
+        "boolean",
+        "timestamp",
+        "date",
+        "enum",
+        "json",
+        "array",
+        "file"
+      ],
+      "description": "The data type of a field."
+    },
+    "FieldSchema": {
+      "type": "object",
+      "description": "Definition of a single field in a resource schema.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/FieldType"
+        },
+        "primary": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field is the primary key. Exactly one field must be primary."
+        },
+        "generated": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field is auto-generated (e.g., uuid v4, timestamps)."
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field is required (NOT NULL + validated on input)."
+        },
+        "unique": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field has a unique constraint."
+        },
+        "nullable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field is explicitly nullable."
+        },
+        "ref": {
+          "type": "string",
+          "description": "Foreign key reference in 'resource.field' format (e.g., 'organizations.id'). Field type must be uuid.",
+          "pattern": "^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*$"
+        },
+        "min": {
+          "description": "Minimum value (number) or minimum length (string)."
+        },
+        "max": {
+          "description": "Maximum value (number) or maximum length (string)."
+        },
+        "format": {
+          "type": "string",
+          "description": "String format validation. Only valid when type is 'string'.",
+          "enum": [
+            "email",
+            "url",
+            "uuid"
+          ]
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Allowed values for enum-type fields. Required when type is 'enum'."
+        },
+        "default": {
+          "description": "Default value for this field."
+        },
+        "sensitive": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field contains sensitive data (redacted in logs)."
+        },
+        "search": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field is included in full-text search."
+        },
+        "items": {
+          "type": "string",
+          "description": "Element type for array fields. Required when type is 'array'.",
+          "enum": [
+            "uuid",
+            "string",
+            "integer",
+            "bigint",
+            "number",
+            "boolean",
+            "timestamp",
+            "date"
+          ]
+        }
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "GET",
+        "POST",
+        "PATCH",
+        "PUT",
+        "DELETE"
+      ]
+    },
+    "AuthRule": {
+      "description": "Authentication rule. Use 'public' for no auth, 'owner' for ownership check, or an array of role strings.",
+      "oneOf": [
+        {
+          "const": "public"
+        },
+        {
+          "const": "owner"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Requires JWT with one of these roles. Use 'owner' in the array to combine role + ownership check."
+        }
+      ]
+    },
+    "PaginationStyle": {
+      "type": "string",
+      "enum": [
+        "cursor",
+        "offset"
+      ],
+      "description": "Pagination strategy for list endpoints."
+    },
+    "CacheSpec": {
+      "type": "object",
+      "description": "Cache configuration for an endpoint.",
+      "required": [
+        "ttl"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ttl": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Time-to-live in seconds."
+        },
+        "invalidate_on": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "create",
+              "update",
+              "delete"
+            ]
+          },
+          "description": "Events that invalidate this cache."
+        }
+      }
+    },
+    "UploadSpec": {
+      "type": "object",
+      "description": "File upload configuration for an endpoint.",
+      "required": [
+        "field",
+        "storage",
+        "max_size"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "Schema field that stores the file URL. Must be type 'file'."
+        },
+        "storage": {
+          "type": "string",
+          "enum": [
+            "local",
+            "s3",
+            "gcs",
+            "azure"
+          ],
+          "description": "Storage backend."
+        },
+        "max_size": {
+          "type": "string",
+          "description": "Maximum file size (e.g., '5mb', '10mb').",
+          "pattern": "^[0-9]+[kmg]b$"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowed file extensions (e.g., ['jpg', 'png', 'pdf'])."
+        }
+      }
+    },
+    "ControllerSpec": {
+      "type": "object",
+      "description": "Controller specification for synchronous in-request business logic. Functions live in resources/<resource>.controller.rs.",
+      "additionalProperties": false,
+      "properties": {
+        "before": {
+          "type": "string",
+          "description": "Function name called before the DB operation. Prefix with 'wasm:' for WASM plugins (e.g., 'wasm:./plugins/validator.wasm')."
+        },
+        "after": {
+          "type": "string",
+          "description": "Function name called after the DB operation. Prefix with 'wasm:' for WASM plugins."
+        }
+      }
+    },
+    "EndpointSpec": {
+      "type": "object",
+      "description": "Specification for a single endpoint in a resource.",
+      "required": [
+        "method",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "$ref": "#/$defs/HttpMethod"
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path pattern (e.g., '/users', '/users/:id'). Auto-prefixed with /v{version}.",
+          "pattern": "^/"
+        },
+        "auth": {
+          "$ref": "#/$defs/AuthRule"
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Schema fields accepted as input for create/update. Each must exist in schema."
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Schema fields available as query filters. Each must exist in schema."
+        },
+        "search": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Schema fields included in full-text search. Each must exist in schema."
+        },
+        "pagination": {
+          "$ref": "#/$defs/PaginationStyle"
+        },
+        "sort": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Schema fields available for sorting. Each must exist in schema."
+        },
+        "cache": {
+          "$ref": "#/$defs/CacheSpec"
+        },
+        "controller": {
+          "$ref": "#/$defs/ControllerSpec"
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Events to emit after successful execution (e.g., ['user.created'])."
+        },
+        "jobs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Background jobs to enqueue after successful execution (e.g., ['send_welcome_email'])."
+        },
+        "upload": {
+          "$ref": "#/$defs/UploadSpec"
+        },
+        "soft_delete": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this endpoint performs a soft delete. Requires an 'updated_at' field in schema."
+        }
+      }
+    },
+    "RelationType": {
+      "type": "string",
+      "enum": [
+        "belongs_to",
+        "has_many",
+        "has_one"
+      ]
+    },
+    "RelationSpec": {
+      "type": "object",
+      "description": "Specification for a relationship to another resource.",
+      "required": [
+        "resource",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "Name of the related resource."
+        },
+        "type": {
+          "$ref": "#/$defs/RelationType"
+        },
+        "key": {
+          "type": "string",
+          "description": "Local foreign key field. Required for belongs_to."
+        },
+        "foreign_key": {
+          "type": "string",
+          "description": "Foreign key on the related resource. Required for has_many and has_one."
+        }
+      }
+    },
+    "IndexSpec": {
+      "type": "object",
+      "description": "Specification for a database index.",
+      "required": [
+        "fields"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Fields included in this index. Each must exist in schema."
+        },
+        "unique": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this is a unique index."
+        },
+        "order": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Sort order for the index."
+        }
+      }
+    }
+  }
+}

--- a/docs/superpowers/plans/2026-04-20-llm-first-dx.md
+++ b/docs/superpowers/plans/2026-04-20-llm-first-dx.md
@@ -1,0 +1,1209 @@
+# LLM-First Developer Experience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Shaperail usable by AI models (Claude, ChatGPT) with minimal context, a single reference file, and self-correcting CLI errors.
+
+**Architecture:** Three pillars — (1) `docs/llm-guide.md` as the canonical single-file context, (2) `docs/llm-reference.md` as a dense quick-lookup table, and (3) a new `shaperail llm-context` CLI command that dumps project state in 50–100 lines for brownfield use. The `Diagnostic` struct already has `fix` and `example` fields; no changes to error output format needed.
+
+**Tech Stack:** Rust (shaperail-cli, shaperail-core, shaperail-codegen), Markdown (docs), clap (CLI flag definitions), serde_json (JSON output).
+
+---
+
+## Task 1: Create `docs/llm-guide.md`
+
+**Files:**
+- Create: `docs/llm-guide.md`
+
+- [ ] **Step 1: Write `docs/llm-guide.md` with the exact content below**
+
+Create `/Users/Mahin/Desktop/shaperail/docs/llm-guide.md` with this exact content:
+
+```markdown
+# Shaperail LLM Guide
+
+Load this file as your sole context. You do not need other docs to build in Shaperail.
+
+---
+
+## 1. Resource File Structure
+
+Every resource is a YAML file at `resources/<name>.yaml`.
+
+```yaml
+resource: <name>      # snake_case plural noun (required)
+version: <int>        # >= 1 — sets route prefix /v{n}/... (required)
+db: <db_name>         # named DB from config.databases (optional)
+tenant_key: <field>   # schema field name for row-level tenant isolation (optional)
+schema: ...           # map of field definitions (required, must include a primary key)
+endpoints: ...        # map of endpoint definitions (optional)
+relations: ...        # map of relation definitions (optional)
+indexes: ...          # list of index definitions (optional)
+```
+
+---
+
+## 2. Field Types
+
+| Type      | Requires        | Valid Options                                                         |
+|-----------|-----------------|-----------------------------------------------------------------------|
+| uuid      |                 | primary, generated, required, unique, ref, sensitive                  |
+| string    |                 | required, unique, min, max, format, sensitive                         |
+| integer   |                 | required, unique, min, max, default                                   |
+| float     |                 | required, min, max, default                                           |
+| boolean   |                 | required, default                                                     |
+| timestamp |                 | generated, required, nullable                                         |
+| enum      | values          | values (required), default, required                                  |
+| json      |                 | required, nullable                                                    |
+| array     | items           | items (required — e.g. `items: string`), required                    |
+
+`format` valid values: `email`, `url`, `slug`, `phone` (string fields only).  
+`ref` format: `resource_name.field_name` — the field must be `type: uuid`.
+
+---
+
+## 3. Field Options Reference
+
+| Option    | Type    | Applies to           | Effect                                                          |
+|-----------|---------|----------------------|-----------------------------------------------------------------|
+| primary   | bool    | uuid                 | Marks as primary key                                            |
+| generated | bool    | uuid, timestamp      | Auto-generated (UUID v7 / NOW()) — do not include in input     |
+| required  | bool    | any                  | NOT NULL in DB, required in create/update input                |
+| unique    | bool    | any                  | UNIQUE constraint                                               |
+| nullable  | bool    | timestamp, json      | Allows null — overrides `required`                              |
+| min       | number  | string, int, float   | Min length (string) or minimum value (numbers)                 |
+| max       | number  | string, int, float   | Max length (string) or maximum value (numbers)                 |
+| format    | string  | string only          | Validation format: email / url / slug / phone                  |
+| values    | list    | enum only            | Allowed enum values — required when `type: enum`               |
+| default   | any     | enum, bool, int      | Default value. For enum must be one of `values`                |
+| ref       | string  | uuid only            | Foreign key reference in `resource.field` format               |
+| items     | string  | array only           | Element type — required when `type: array`                     |
+| sensitive | bool    | uuid, string         | Redacted in logs, omitted from list responses                  |
+
+---
+
+## 4. Endpoints
+
+### Convention-based (method + path inferred from action name)
+
+| Action | Method | Path               |
+|--------|--------|--------------------|
+| list   | GET    | /v{n}/{resource}   |
+| create | POST   | /v{n}/{resource}   |
+| get    | GET    | /v{n}/{resource}/{id} |
+| update | PATCH  | /v{n}/{resource}/{id} |
+| delete | DELETE | /v{n}/{resource}/{id} |
+
+For custom endpoints, provide `method:` and `path:` explicitly.
+
+### Valid Keys per Endpoint Type
+
+| Key         | list | create | get | update | delete | custom |
+|-------------|:----:|:------:|:---:|:------:|:------:|:------:|
+| auth        | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| input       |      | ✓      |     | ✓      |        | ✓      |
+| filters     | ✓    |        |     |        |        |        |
+| search      | ✓    |        |     |        |        |        |
+| sort        | ✓    |        |     |        |        |        |
+| pagination  | ✓    |        |     |        |        |        |
+| cache       | ✓    | ✓      | ✓   |        |        | ✓      |
+| controller  | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| events      |      | ✓      |     | ✓      | ✓      |        |
+| jobs        |      | ✓      |     | ✓      | ✓      |        |
+| soft_delete |      |        |     |        | ✓      |        |
+| upload      |      | ✓      |     |        |        |        |
+| method      |      |        |     |        |        | ✓      |
+| path        |      |        |     |        |        | ✓      |
+
+Key details:
+- `auth`: list of role names from your auth config, or `owner` (matches record creator)
+- `pagination`: `cursor` (default) or `offset` — no other values
+- `cache`: `{ ttl: <seconds> }`
+- `controller`: `{ before: <fn_name> }` and/or `{ after: <fn_name> }` — fn in `resources/<name>.controller.rs`
+- `input`: list of field names from `schema:` — not field definitions
+- `sort`: list of field names that clients can sort by
+- `filters`: list of field names that clients can filter on
+- `search`: list of string/text field names for full-text search
+
+---
+
+## 5. Controller Pattern
+
+Reference a controller in an endpoint:
+
+```yaml
+endpoints:
+  create:
+    auth: [admin]
+    input: [email, name, org_id]
+    controller: { before: validate_org }
+```
+
+The function lives in `resources/<resource_name>.controller.rs` (same directory as the YAML):
+
+```rust
+// resources/users.controller.rs
+use shaperail_runtime::ControllerContext;
+
+// before hook — return Err("message") to abort with HTTP 422
+pub async fn validate_org(ctx: &mut ControllerContext) -> Result<(), String> {
+    let org_id = ctx.input["org_id"].as_str().ok_or("org_id required")?;
+    if org_id.is_empty() {
+        return Err("org_id must not be empty".into());
+    }
+    Ok(())
+}
+
+// after hook — ctx.output has the created/updated record
+pub async fn notify_team(ctx: &ControllerContext) -> Result<(), String> {
+    let _id = &ctx.output["id"];
+    // fire side effects here
+    Ok(())
+}
+```
+
+`ControllerContext` fields:
+| Field       | Type                  | Available in   | Description                              |
+|-------------|-----------------------|----------------|------------------------------------------|
+| input       | serde_json::Value     | before + after | Request body (before) / saved record (after) |
+| output      | serde_json::Value     | after only     | The record returned by the operation     |
+| user_id     | Option<uuid::Uuid>    | before + after | Authenticated user, None if no auth      |
+| tenant_id   | Option<uuid::Uuid>    | before + after | Current tenant, None if no multi-tenancy |
+| resource    | &str                  | before + after | Resource name (e.g., "users")            |
+
+---
+
+## 6. Relations
+
+```yaml
+relations:
+  # belongs_to — this resource holds the foreign key
+  org:     { resource: organizations, type: belongs_to, key: org_id }
+
+  # has_many — the other resource holds the foreign key
+  posts:   { resource: posts, type: has_many, foreign_key: author_id }
+
+  # has_one — same as has_many but returns a single record
+  profile: { resource: profiles, type: has_one, foreign_key: user_id }
+```
+
+Rules:
+- `belongs_to` requires `key:` — the FK field name **on this resource's schema**
+- `has_many` / `has_one` require `foreign_key:` — the FK field name **on the related resource**
+- `resource:` must exactly match the `resource:` name in the related YAML file
+- Relations do NOT auto-create schema fields — declare the FK field in `schema:` explicitly
+
+---
+
+## 7. Indexes
+
+```yaml
+indexes:
+  - fields: [org_id, role]           # composite index
+  - fields: [email], unique: true    # unique constraint index
+  - fields: [created_at], order: desc # descending order index
+```
+
+- `fields`: list of field names from `schema:` (min 1)
+- `unique`: bool (optional, default false)
+- `order`: `asc` or `desc` (optional, default asc)
+
+---
+
+## 8. Do's and Don'ts
+
+| Rule                        | Correct                                              | Wrong                                    |
+|-----------------------------|------------------------------------------------------|------------------------------------------|
+| Top-level key               | `resource: users`                                    | `name: users`                            |
+| Enum field                  | `{ type: enum, values: [admin, member] }`            | `{ type: enum }`                         |
+| Array field                 | `{ type: array, items: string }`                     | `{ type: array }`                        |
+| Soft delete schema          | `deleted_at: { type: timestamp, nullable: true }` + `soft_delete: true` on delete endpoint | `soft_delete: true` alone |
+| Foreign key reference       | `ref: organizations.id`                              | `ref: organizations`                     |
+| FK field type               | `{ type: uuid, ref: organizations.id }`              | `{ type: string, ref: organizations.id }` |
+| Pagination value            | `pagination: cursor` or `pagination: offset`         | `pagination: page`                       |
+| Input format                | `input: [email, name, role]`                         | `input: { email: ..., name: ... }`       |
+| Tenant key field            | `tenant_key: org_id` + `org_id: { type: uuid, required: true }` in schema | `tenant_key: org_id` without schema field |
+| Controller reference        | `controller: { before: validate_org }`               | `controller: { before: validate_org.rs }` |
+| Relation FK on belongs_to   | `{ type: belongs_to, key: org_id }`                  | `{ type: belongs_to, foreign_key: org_id }` |
+| Relation FK on has_many     | `{ type: has_many, foreign_key: user_id }`           | `{ type: has_many, key: user_id }`       |
+
+---
+
+## 9. Common Patterns
+
+### Basic CRUD Resource
+```yaml
+resource: products
+version: 1
+schema:
+  id:          { type: uuid, primary: true, generated: true }
+  name:        { type: string, min: 1, max: 200, required: true }
+  price:       { type: float, min: 0, required: true }
+  active:      { type: boolean, default: true }
+  created_at:  { type: timestamp, generated: true }
+  updated_at:  { type: timestamp, generated: true }
+endpoints:
+  list:   { auth: [member, admin] }
+  get:    { auth: [member, admin] }
+  create: { auth: [admin], input: [name, price, active] }
+  update: { auth: [admin], input: [name, price, active] }
+  delete: { auth: [admin] }
+```
+
+### User Resource with Auth + Roles
+```yaml
+resource: users
+version: 1
+schema:
+  id:         { type: uuid, primary: true, generated: true }
+  email:      { type: string, format: email, unique: true, required: true }
+  name:       { type: string, min: 1, max: 200, required: true }
+  role:       { type: enum, values: [admin, member], default: member }
+  org_id:     { type: uuid, ref: organizations.id, required: true }
+  created_at: { type: timestamp, generated: true }
+  updated_at: { type: timestamp, generated: true }
+endpoints:
+  list:   { auth: [admin], filters: [role, org_id], search: [name, email] }
+  get:    { auth: [admin, owner] }
+  create: { auth: [admin], input: [email, name, role, org_id] }
+  update: { auth: [admin, owner], input: [name, role] }
+  delete: { auth: [admin] }
+relations:
+  organization: { resource: organizations, type: belongs_to, key: org_id }
+```
+
+### Soft Delete
+```yaml
+schema:
+  ...
+  deleted_at: { type: timestamp, nullable: true }
+endpoints:
+  delete: { auth: [admin], soft_delete: true }
+```
+
+### Multi-Tenant Resource
+```yaml
+resource: projects
+version: 1
+tenant_key: org_id
+schema:
+  id:     { type: uuid, primary: true, generated: true }
+  org_id: { type: uuid, ref: organizations.id, required: true }
+  name:   { type: string, required: true }
+endpoints:
+  list:   { auth: [member, admin] }
+  create: { auth: [admin], input: [name] }
+```
+
+### List with Caching + Filtering + Cursor Pagination
+```yaml
+endpoints:
+  list:
+    auth: [member, admin]
+    filters: [status, category_id]
+    search: [title, description]
+    sort: [created_at, title]
+    pagination: cursor
+    cache: { ttl: 30 }
+```
+
+### Create with Controller + Events + Jobs
+```yaml
+endpoints:
+  create:
+    auth: [admin]
+    input: [email, name, role]
+    controller: { before: validate_email, after: send_notifications }
+    events: [user.created]
+    jobs: [send_welcome_email]
+```
+
+---
+
+## 10. Error Code Quick Reference
+
+Run `shaperail check --json` to get structured errors with fix suggestions.
+
+| Code  | Trigger                                | Fix                                                             |
+|-------|----------------------------------------|-----------------------------------------------------------------|
+| SR001 | resource name empty                    | Add `resource: <name>` (snake_case plural)                     |
+| SR002 | version is 0 or missing                | Set `version: 1`                                               |
+| SR003 | schema has no fields                   | Add at least one field                                          |
+| SR004 | no primary key                         | Add `primary: true` to one field (typically `id`)              |
+| SR005 | multiple primary keys                  | Remove `primary: true` from all but one field                  |
+| SR010 | enum field missing values              | Add `values: [a, b, c]` to the field                           |
+| SR011 | non-enum field has values              | Change `type: enum` or remove `values:`                        |
+| SR012 | ref on non-uuid field                  | Change field type to `uuid`                                    |
+| SR013 | ref not in resource.field format       | Use `ref: resource_name.field_name` (e.g., `organizations.id`) |
+| SR014 | array field missing items              | Add `items: string` (or other type)                            |
+| SR015 | format on non-string field             | Remove `format:` or change type to `string`                    |
+| SR016 | primary key not generated              | Add `generated: true` and `required: true` to the pk field     |
+| SR020 | tenant_key field not in schema         | Add the field to `schema:`                                      |
+| SR021 | tenant_key field not uuid+required     | Set field to `{ type: uuid, required: true }`                  |
+| SR030 | controller path not found              | Path is relative to resources/, no `.rs` extension             |
+| SR031 | controller before function not found   | Check function name matches in `.controller.rs`                |
+| SR032 | controller after function not found    | Check function name matches in `.controller.rs`                |
+| SR033 | WASM controller path invalid           | Use `wasm:path/to/plugin.wasm` prefix                          |
+| SR035 | events on unsupported endpoint type    | Remove `events:` — only valid on create/update/delete          |
+| SR036 | jobs on unsupported endpoint type      | Remove `jobs:` — only valid on create/update/delete            |
+| SR040 | input/filter/search/sort field missing | Add field to `schema:` or fix the field name                   |
+| SR041 | soft_delete without deleted_at         | Add `deleted_at: { type: timestamp, nullable: true }` to schema |
+| SR050 | upload on non-create endpoint          | Move `upload:` to a create endpoint                            |
+| SR051 | upload missing field name              | Add `field: <name>` to upload config                           |
+| SR052 | upload field not in schema             | Add the upload field to `schema:`                              |
+| SR053 | upload field wrong type                | Change field type to `string`                                  |
+| SR054 | upload missing max_size_mb             | Add `max_size_mb: 10` to upload config                         |
+| SR060 | relation missing resource name         | Add `resource: <name>` to relation                             |
+| SR061 | belongs_to missing key                 | Add `key: <field_name>` (FK field on this resource)            |
+| SR062 | has_many/has_one missing foreign_key   | Add `foreign_key: <field_name>` (FK on the related resource)   |
+| SR070 | index has no fields                    | Add at least one field name to `fields:`                       |
+| SR071 | index field not in schema              | Fix field name to match a `schema:` field                      |
+| SR072 | index order invalid                    | Use `order: asc` or `order: desc`                              |
+
+---
+
+## 11. CLI Reference
+
+```bash
+shaperail init <name>                   # scaffold new project
+shaperail serve                         # start dev server (hot reload)
+shaperail generate                      # run codegen for all resources
+shaperail check [path] [--json]         # validate with structured fix suggestions
+shaperail explain <file>                # dry-run: show routes, table, relations
+shaperail diff                          # show what codegen would change
+shaperail llm-context [--resource <n>] [--json]  # dump project context for LLM
+shaperail migrate                       # apply pending SQL migrations
+shaperail routes                        # list all routes with auth requirements
+shaperail export openapi                # output OpenAPI 3.1 spec
+shaperail export json-schema            # output JSON Schema for resource YAML
+shaperail resource create <name> [--archetype basic|user|content|tenant|lookup]
+```
+```
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `wc -l docs/llm-guide.md`  
+Expected: ~250–320 lines
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/llm-guide.md
+git commit -m "docs: add llm-guide.md — single-file LLM context for Shaperail"
+```
+
+---
+
+## Task 2: Create `docs/llm-reference.md`
+
+**Files:**
+- Create: `docs/llm-reference.md`
+
+- [ ] **Step 1: Write `docs/llm-reference.md`**
+
+Create `/Users/Mahin/Desktop/shaperail/docs/llm-reference.md` with this exact content:
+
+```markdown
+# Shaperail Quick Reference
+
+Terse lookup tables. For patterns and examples, see [llm-guide.md](llm-guide.md).
+
+---
+
+## Field Types
+
+| Type      | Required sub-keys | Notes                                      |
+|-----------|------------------|--------------------------------------------|
+| uuid      | —                | Use for PKs and FKs                        |
+| string    | —                | Supports format, min, max                  |
+| integer   | —                | Supports min, max, default                 |
+| float     | —                | Supports min, max, default                 |
+| boolean   | —                | Supports default                           |
+| timestamp | —                | Use generated:true for auto-timestamps     |
+| enum      | values           | values is required                         |
+| json      | —                | Unstructured JSON blob                     |
+| array     | items            | items type is required                     |
+
+## Endpoint Keys by Type
+
+| Key         | list | create | get | update | delete | custom |
+|-------------|:----:|:------:|:---:|:------:|:------:|:------:|
+| auth        | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| input       |      | ✓      |     | ✓      |        | ✓      |
+| filters     | ✓    |        |     |        |        |        |
+| search      | ✓    |        |     |        |        |        |
+| sort        | ✓    |        |     |        |        |        |
+| pagination  | ✓    |        |     |        |        |        |
+| cache       | ✓    | ✓      | ✓   |        |        | ✓      |
+| controller  | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| events      |      | ✓      |     | ✓      | ✓      |        |
+| jobs        |      | ✓      |     | ✓      | ✓      |        |
+| soft_delete |      |        |     |        | ✓      |        |
+| upload      |      | ✓      |     |        |        |        |
+| method      |      |        |     |        |        | ✓      |
+| path        |      |        |     |        |        | ✓      |
+
+## Relation Types
+
+| Type       | Required key | Description                                   |
+|------------|-------------|-----------------------------------------------|
+| belongs_to | key         | FK is on **this** resource                     |
+| has_many   | foreign_key | FK is on the **other** resource, returns list  |
+| has_one    | foreign_key | FK is on the **other** resource, returns one   |
+
+## Config Keys (`shaperail.config.yaml`)
+
+| Key        | Required | Description                                   |
+|------------|----------|-----------------------------------------------|
+| project    | ✓        | Project name string                           |
+| port       |          | HTTP port (default 3000)                      |
+| workers    |          | `auto` or integer                             |
+| database   |          | Single DB: `type`, `host`, `port`, `name`     |
+| databases  |          | Multi-DB map: `engine` (postgres/mysql/sqlite/mongodb), `url` |
+| cache      |          | Redis: `url`                                  |
+| auth       |          | `provider: jwt`, `secret_env: JWT_SECRET`     |
+| storage    |          | `provider: s3/gcs/azure/local`, `bucket`      |
+| logging    |          | `level`, `format: json/text`                  |
+| events     |          | `backend: redis`                              |
+| protocols  |          | List: `[rest, graphql, grpc]`                 |
+
+## CLI Commands
+
+| Command                               | Description                                          |
+|---------------------------------------|------------------------------------------------------|
+| `shaperail init <name>`               | Scaffold new project                                 |
+| `shaperail serve [--port N]`          | Start dev server with hot reload                     |
+| `shaperail generate`                  | Run codegen for all resources                        |
+| `shaperail check [path] [--json]`     | Validate with structured fix suggestions             |
+| `shaperail explain <file>`            | Show routes, table schema, relations                 |
+| `shaperail diff`                      | Show codegen changes (dry run)                       |
+| `shaperail llm-context [--resource N] [--json]` | Dump project context for LLM          |
+| `shaperail migrate [--rollback]`      | Apply or rollback SQL migrations                     |
+| `shaperail seed [path]`               | Load fixture YAML into database                      |
+| `shaperail routes`                    | List routes with auth requirements                   |
+| `shaperail export openapi`            | Output OpenAPI 3.1 spec                              |
+| `shaperail export sdk --lang ts`      | Generate TypeScript SDK                              |
+| `shaperail export json-schema`        | Output JSON Schema for resource YAML                 |
+| `shaperail resource create <name> [--archetype basic\|user\|content\|tenant\|lookup]` | Scaffold resource |
+| `shaperail doctor`                    | Check system dependencies                            |
+
+## Archetypes
+
+| Archetype | Fields included                                                |
+|-----------|----------------------------------------------------------------|
+| basic     | id, created_at, updated_at                                    |
+| user      | id, email, name, role, password_hash, created_at, updated_at  |
+| content   | id, title, body, status, author_id, created_at, updated_at    |
+| tenant    | id, name, plan, created_at, updated_at (+ tenant isolation)   |
+| lookup    | id, code, label, active, sort_order                           |
+
+## Error Codes
+
+| Code  | Trigger                              | Fix                                           |
+|-------|--------------------------------------|-----------------------------------------------|
+| SR001 | Empty resource name                  | Add `resource: <name>`                        |
+| SR002 | Version < 1                          | Set `version: 1`                              |
+| SR003 | Empty schema                         | Add at least one field                        |
+| SR004 | No primary key                       | Add `primary: true` to one field              |
+| SR005 | Multiple primary keys                | Remove `primary: true` from extras            |
+| SR010 | Enum missing values                  | Add `values: [a, b]`                          |
+| SR011 | Values on non-enum                   | Change type to `enum` or remove `values:`     |
+| SR012 | ref on non-uuid field                | Change type to `uuid`                         |
+| SR013 | ref wrong format                     | Use `ref: resource.field`                     |
+| SR014 | Array missing items                  | Add `items: string`                           |
+| SR015 | format on non-string                 | Remove or change type to `string`             |
+| SR016 | PK not generated                     | Add `generated: true, required: true`         |
+| SR020 | tenant_key field absent              | Add field to `schema:`                        |
+| SR021 | tenant_key field wrong type          | Set `{ type: uuid, required: true }`          |
+| SR040 | input/filter/search/sort field absent | Add to `schema:` or fix name                 |
+| SR041 | soft_delete without deleted_at       | Add `deleted_at: { type: timestamp, nullable: true }` |
+| SR060 | Relation missing resource            | Add `resource: <name>`                        |
+| SR061 | belongs_to missing key               | Add `key: <field>`                            |
+| SR062 | has_many/has_one missing foreign_key | Add `foreign_key: <field>`                    |
+| SR070 | Index fields empty                   | Add at least one field                        |
+| SR071 | Index field not in schema            | Fix field name                                |
+| SR072 | Index order invalid                  | Use `asc` or `desc`                           |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/llm-reference.md
+git commit -m "docs: add llm-reference.md — machine-optimized quick lookup tables"
+```
+
+---
+
+## Task 3: Implement `shaperail llm-context` CLI Command
+
+**Files:**
+- Create: `shaperail-cli/src/commands/llm_context.rs`
+- Modify: `shaperail-cli/src/commands/mod.rs` (add `pub mod llm_context;`)
+- Modify: `shaperail-cli/src/main.rs` (add `LlmContext` command variant + dispatch)
+
+- [ ] **Step 1: Write the failing test first**
+
+Add this test to the bottom of `shaperail-cli/src/commands/llm_context.rs` (create the file with just the test module first):
+
+```rust
+// shaperail-cli/src/commands/llm_context.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shaperail_core::{DatabaseConfig, ProjectConfig, WorkerCount};
+
+    fn make_config(project: &str) -> ProjectConfig {
+        ProjectConfig {
+            project: project.to_string(),
+            port: 3000,
+            workers: WorkerCount::Auto,
+            database: Some(DatabaseConfig {
+                db_type: "postgresql".to_string(),
+                host: "localhost".to_string(),
+                port: 5432,
+                name: "test_db".to_string(),
+                pool_size: 5,
+            }),
+            databases: None,
+            cache: None,
+            auth: None,
+            storage: None,
+            logging: None,
+            events: None,
+            protocols: vec!["rest".to_string()],
+            graphql: None,
+            grpc: None,
+        }
+    }
+
+    #[test]
+    fn db_summary_single_db() {
+        let config = make_config("my-app");
+        assert_eq!(db_summary(&config), "postgresql");
+    }
+
+    #[test]
+    fn auth_summary_no_auth() {
+        let config = make_config("my-app");
+        assert_eq!(auth_summary(&config), "none");
+    }
+
+    #[test]
+    fn auth_summary_with_jwt() {
+        let mut config = make_config("my-app");
+        config.auth = Some(shaperail_core::AuthConfig {
+            provider: "jwt".to_string(),
+            secret_env: "JWT_SECRET".to_string(),
+        });
+        assert_eq!(auth_summary(&config), "jwt");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (module doesn't exist yet)**
+
+```bash
+cargo test -p shaperail-cli 2>&1 | head -20
+```
+
+Expected: compile error — `llm_context` module not declared.
+
+- [ ] **Step 3: Write the full implementation**
+
+Replace the file with the complete implementation:
+
+```rust
+// shaperail-cli/src/commands/llm_context.rs
+use shaperail_core::{ProjectConfig, RelationType};
+
+pub fn run(resource_filter: Option<&str>, json_output: bool) -> i32 {
+    let config = match super::load_config() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let resources = match super::load_all_resources() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let mut filtered: Vec<_> = resources.iter().collect();
+    if let Some(name) = resource_filter {
+        filtered.retain(|r| r.resource == name);
+        if filtered.is_empty() {
+            eprintln!("No resource named '{name}' found in resources/");
+            return 1;
+        }
+    }
+    filtered.sort_by(|a, b| a.resource.cmp(&b.resource));
+
+    let all_diags: Vec<_> = filtered
+        .iter()
+        .flat_map(|r| {
+            shaperail_codegen::diagnostics::diagnose_resource(r)
+                .into_iter()
+                .map(|d| (r.resource.clone(), d))
+        })
+        .collect();
+
+    if json_output {
+        print_json(&config, &filtered, &all_diags);
+    } else {
+        print_markdown(&config, &filtered, &all_diags);
+    }
+    0
+}
+
+fn db_summary(config: &ProjectConfig) -> String {
+    if let Some(ref dbs) = config.databases {
+        let mut engines: Vec<String> = dbs
+            .values()
+            .map(|d| format!("{:?}", d.engine).to_lowercase())
+            .collect();
+        engines.sort();
+        engines.dedup();
+        engines.join(", ")
+    } else if let Some(ref db) = config.database {
+        db.db_type.clone()
+    } else {
+        "unknown".into()
+    }
+}
+
+fn auth_summary(config: &ProjectConfig) -> String {
+    config
+        .auth
+        .as_ref()
+        .map(|a| a.provider.clone())
+        .unwrap_or_else(|| "none".into())
+}
+
+fn print_markdown(
+    config: &ProjectConfig,
+    resources: &[&shaperail_core::ResourceDefinition],
+    diags: &[(String, shaperail_codegen::diagnostics::Diagnostic)],
+) {
+    println!("# Project: {}", config.project);
+    println!(
+        "Database: {} | Auth: {} | Port: {}",
+        db_summary(config),
+        auth_summary(config),
+        config.port
+    );
+    println!();
+    println!("## Resources ({})", resources.len());
+    println!();
+
+    for rd in resources {
+        println!("### {} (v{})", rd.resource, rd.version);
+
+        // Fields — one compact line
+        let field_strs: Vec<String> = rd
+            .schema
+            .iter()
+            .map(|(name, field)| {
+                let mut parts = vec![field.field_type.to_string()];
+                if field.primary {
+                    parts.push("pk".into());
+                }
+                if field.generated {
+                    parts.push("generated".into());
+                }
+                if field.required {
+                    parts.push("required".into());
+                }
+                if field.unique {
+                    parts.push("unique".into());
+                }
+                if let Some(ref r) = field.reference {
+                    parts.push(format!("fk→{r}"));
+                }
+                if let Some(ref vals) = field.values {
+                    parts.push(format!("[{}]", vals.join(",")));
+                }
+                if let Some(ref def) = field.default {
+                    parts.push(format!("default:{def}"));
+                }
+                format!("{name}({})", parts.join(","))
+            })
+            .collect();
+        println!("Fields: {}", field_strs.join(", "));
+
+        // Endpoints
+        if let Some(ref eps) = rd.endpoints {
+            let mut ep_list: Vec<(String, String)> = eps
+                .iter()
+                .map(|(action, ep)| {
+                    let auth_str = match &ep.auth {
+                        Some(a) => format!("{a}"),
+                        None => "none".into(),
+                    };
+                    (action.clone(), format!("{action}[{auth_str}]"))
+                })
+                .collect();
+            ep_list.sort_by(|a, b| a.0.cmp(&b.0));
+            println!(
+                "Endpoints: {}",
+                ep_list
+                    .iter()
+                    .map(|(_, s)| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        // Relations
+        if let Some(ref rels) = rd.relations {
+            let mut rel_list: Vec<(String, String)> = rels
+                .iter()
+                .map(|(name, rel)| {
+                    let kind = match rel.relation_type {
+                        RelationType::BelongsTo => "belongs_to",
+                        RelationType::HasMany => "has_many",
+                        RelationType::HasOne => "has_one",
+                    };
+                    (name.clone(), format!("{name}({kind}→{})", rel.resource))
+                })
+                .collect();
+            rel_list.sort_by(|a, b| a.0.cmp(&b.0));
+            println!(
+                "Relations: {}",
+                rel_list
+                    .iter()
+                    .map(|(_, s)| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        // Cache
+        if let Some(ref eps) = rd.endpoints {
+            let mut cached: Vec<String> = eps
+                .iter()
+                .filter_map(|(action, ep)| {
+                    ep.cache.as_ref().map(|c| format!("{action}({}s)", c.ttl))
+                })
+                .collect();
+            if !cached.is_empty() {
+                cached.sort();
+                println!("Cache: {}", cached.join(", "));
+            }
+        }
+
+        // Tenant key
+        if let Some(ref tk) = rd.tenant_key {
+            println!("Tenant key: {tk}");
+        }
+
+        // Soft delete
+        let has_soft_delete = rd
+            .endpoints
+            .as_ref()
+            .map(|eps| eps.values().any(|ep| ep.soft_delete))
+            .unwrap_or(false);
+        if has_soft_delete {
+            println!("Soft delete: enabled");
+        }
+
+        // Per-resource validation errors
+        let res_diags: Vec<_> = diags
+            .iter()
+            .filter(|(r, _)| r == &rd.resource)
+            .collect();
+        if !res_diags.is_empty() {
+            println!(
+                "Errors: {}",
+                res_diags
+                    .iter()
+                    .map(|(_, d)| format!("[{}] {}", d.code, d.error))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
+        }
+
+        println!();
+    }
+
+    // Validation summary
+    if diags.is_empty() {
+        println!("## Validation\n✓ No errors found");
+    } else {
+        println!("## Validation\n⚠ {} issue(s):", diags.len());
+        for (resource, d) in diags {
+            println!("  {resource} [{}] {} → {}", d.code, d.error, d.fix);
+        }
+    }
+}
+
+fn print_json(
+    config: &ProjectConfig,
+    resources: &[&shaperail_core::ResourceDefinition],
+    diags: &[(String, shaperail_codegen::diagnostics::Diagnostic)],
+) {
+    let resource_list: Vec<serde_json::Value> = resources
+        .iter()
+        .map(|rd| {
+            let fields: Vec<serde_json::Value> = rd
+                .schema
+                .iter()
+                .map(|(name, field)| {
+                    serde_json::json!({
+                        "name": name,
+                        "type": field.field_type.to_string(),
+                        "primary": field.primary,
+                        "generated": field.generated,
+                        "required": field.required,
+                        "unique": field.unique,
+                        "ref": field.reference,
+                        "values": field.values,
+                        "default": field.default,
+                    })
+                })
+                .collect();
+
+            let endpoints: Vec<serde_json::Value> = rd
+                .endpoints
+                .as_ref()
+                .map(|eps| {
+                    eps.iter()
+                        .map(|(action, ep)| {
+                            serde_json::json!({
+                                "action": action,
+                                "method": ep.method(),
+                                "path": format!("/v{}{}", rd.version, ep.path()),
+                                "auth": ep.auth.as_ref().map(|a| format!("{a}")),
+                                "cache_ttl": ep.cache.as_ref().map(|c| c.ttl),
+                                "soft_delete": ep.soft_delete,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let relations: Vec<serde_json::Value> = rd
+                .relations
+                .as_ref()
+                .map(|rels| {
+                    rels.iter()
+                        .map(|(name, rel)| {
+                            let kind = match rel.relation_type {
+                                RelationType::BelongsTo => "belongs_to",
+                                RelationType::HasMany => "has_many",
+                                RelationType::HasOne => "has_one",
+                            };
+                            serde_json::json!({
+                                "name": name,
+                                "type": kind,
+                                "resource": rel.resource,
+                                "key": rel.key,
+                                "foreign_key": rel.foreign_key,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let errors: Vec<serde_json::Value> = diags
+                .iter()
+                .filter(|(r, _)| r == &rd.resource)
+                .map(|(_, d)| {
+                    serde_json::json!({
+                        "code": d.code,
+                        "error": d.error,
+                        "fix": d.fix,
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "name": rd.resource,
+                "version": rd.version,
+                "tenant_key": rd.tenant_key,
+                "fields": fields,
+                "endpoints": endpoints,
+                "relations": relations,
+                "errors": errors,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "project": {
+            "name": config.project,
+            "database": db_summary(config),
+            "auth": auth_summary(config),
+            "port": config.port,
+        },
+        "resources": resource_list,
+        "validation": {
+            "total_errors": diags.len(),
+            "clean": diags.is_empty(),
+        },
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shaperail_core::{DatabaseConfig, ProjectConfig, WorkerCount};
+
+    fn make_config(project: &str) -> ProjectConfig {
+        ProjectConfig {
+            project: project.to_string(),
+            port: 3000,
+            workers: WorkerCount::Auto,
+            database: Some(DatabaseConfig {
+                db_type: "postgresql".to_string(),
+                host: "localhost".to_string(),
+                port: 5432,
+                name: "test_db".to_string(),
+                pool_size: 5,
+            }),
+            databases: None,
+            cache: None,
+            auth: None,
+            storage: None,
+            logging: None,
+            events: None,
+            protocols: vec!["rest".to_string()],
+            graphql: None,
+            grpc: None,
+        }
+    }
+
+    #[test]
+    fn db_summary_single_db() {
+        let config = make_config("my-app");
+        assert_eq!(db_summary(&config), "postgresql");
+    }
+
+    #[test]
+    fn auth_summary_no_auth() {
+        let config = make_config("my-app");
+        assert_eq!(auth_summary(&config), "none");
+    }
+
+    #[test]
+    fn auth_summary_with_jwt() {
+        let mut config = make_config("my-app");
+        config.auth = Some(shaperail_core::AuthConfig {
+            provider: "jwt".to_string(),
+            secret_env: "JWT_SECRET".to_string(),
+        });
+        assert_eq!(auth_summary(&config), "jwt");
+    }
+}
+```
+
+- [ ] **Step 4: Add `pub mod llm_context;` to `shaperail-cli/src/commands/mod.rs`**
+
+Add this line in alphabetical order in the pub mod list (after `jobs_status`, before `migrate`):
+
+```rust
+pub mod llm_context;
+```
+
+- [ ] **Step 5: Add `LlmContext` variant to `Commands` enum in `shaperail-cli/src/main.rs`**
+
+Add after the `JobsStatus` variant (around line 99), before `Resource`:
+
+```rust
+    /// Dump a project-aware context summary for LLM consumption
+    #[command(name = "llm-context")]
+    LlmContext {
+        /// Filter to a single resource by name
+        #[arg(short, long)]
+        resource: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+```
+
+- [ ] **Step 6: Add dispatch arm in `main()` in `shaperail-cli/src/main.rs`**
+
+Add after the `Commands::JobsStatus` arm (around line 183), before `Commands::Resource`:
+
+```rust
+        Commands::LlmContext { resource, json } => {
+            commands::llm_context::run(resource.as_deref(), json)
+        }
+```
+
+- [ ] **Step 7: Check it compiles**
+
+```bash
+cargo build -p shaperail-cli 2>&1
+```
+
+Expected: compiles with no errors. Fix any type mismatches before continuing.
+
+- [ ] **Step 8: Run the tests**
+
+```bash
+cargo test -p shaperail-cli -- llm_context 2>&1
+```
+
+Expected:
+```
+test commands::llm_context::tests::db_summary_single_db ... ok
+test commands::llm_context::tests::auth_summary_no_auth ... ok
+test commands::llm_context::tests::auth_summary_with_jwt ... ok
+```
+
+- [ ] **Step 9: Run clippy**
+
+```bash
+cargo clippy -p shaperail-cli -- -D warnings 2>&1
+```
+
+Expected: no warnings. Fix any lint issues.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add shaperail-cli/src/commands/llm_context.rs \
+        shaperail-cli/src/commands/mod.rs \
+        shaperail-cli/src/main.rs
+git commit -m "feat(shaperail-cli): add llm-context command for project-aware LLM context dumps"
+```
+
+---
+
+## Task 4: Doc Audit — Fix Existing Docs
+
+**Files:**
+- Modify: files in `docs/` that contain anti-patterns (identified during scan)
+
+This task is a systematic scan of the 38 docs for LLM anti-patterns. Fix in-place; do not create new files.
+
+**What to scan for and fix:**
+
+1. **Multiple equivalent syntaxes** — any "you can also...", "alternatively...", or "another way to..." phrasing. Remove the alternative; keep only the canonical form.
+
+2. **Implicit behavior without YAML** — any sentence like "the framework automatically..." or "by default, Shaperail will..." without showing the YAML that enables it. Add the YAML example.
+
+3. **Contradictions with `agent_docs/resource-format.md`** — `agent_docs/resource-format.md` is the source of truth. Any doc that shows different field names, key names, or syntax than what the spec shows must be corrected.
+
+4. **`name:` key instead of `resource:`** — any YAML example showing `name: users` instead of `resource: users`. Fix to `resource:`.
+
+5. **Soft delete without deleted_at in schema** — any example showing `soft_delete: true` without `deleted_at: { type: timestamp, nullable: true }` in the schema.
+
+6. **Relation key confusion** — any `belongs_to` example using `foreign_key:` or any `has_many` example using `key:`. Fix to match the spec.
+
+- [ ] **Step 1: Scan docs for anti-patterns**
+
+Run these greps to find files needing fixes:
+
+```bash
+grep -rl "alternatively\|you can also\|another way\|also works" docs/ --include="*.md"
+grep -rl "name: " docs/ --include="*.md" | xargs grep -l "^name:" 2>/dev/null || true
+grep -rn "soft_delete: true" docs/ --include="*.md"
+```
+
+- [ ] **Step 2: Fix each flagged file**
+
+For each file flagged above:
+- Remove "alternatively" / "you can also" phrasing, keeping only the canonical example
+- Fix any YAML showing `name:` at the resource level to `resource:`
+- Fix any `soft_delete: true` example to include `deleted_at: { type: timestamp, nullable: true }` in the schema section
+
+- [ ] **Step 3: Cross-check key docs against the spec**
+
+Read these docs and verify their YAML examples match `agent_docs/resource-format.md` exactly:
+- `docs/resource-guide.md`
+- `docs/controllers.md`
+- `docs/auth-and-ownership.md`
+- `docs/getting-started.md`
+- `docs/guides.md`
+
+Fix any discrepancies found.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs: audit LLM anti-patterns — remove alternatives, fix syntax examples"
+```
+
+---
+
+## Task 5: JSON Schema Audit and Publish
+
+**Files:**
+- Create: `docs/schema/resource.schema.json`
+- Possibly modify: `shaperail-codegen/src/json_schema.rs` (if gaps found)
+
+- [ ] **Step 1: Generate current JSON Schema and inspect it**
+
+```bash
+cargo run -p shaperail-cli -- export json-schema 2>&1 | head -100
+```
+
+- [ ] **Step 2: Check coverage against `agent_docs/resource-format.md`**
+
+Verify the generated schema includes definitions for all of these top-level keys:
+- `resource`, `version`, `db`, `tenant_key`, `schema`, `endpoints`, `relations`, `indexes`
+
+And for field definitions, all options:
+- `type`, `primary`, `generated`, `required`, `unique`, `nullable`, `min`, `max`, `format`, `values`, `default`, `ref`, `items`, `sensitive`
+
+If any are missing, they need to be added to `shaperail-codegen/src/json_schema.rs`. The function to modify is `generate_resource_json_schema()` starting at line 8.
+
+- [ ] **Step 3: Publish the schema to `docs/schema/resource.schema.json`**
+
+```bash
+mkdir -p docs/schema
+cargo run -p shaperail-cli -- export json-schema --output docs/schema/resource.schema.json
+```
+
+- [ ] **Step 4: Verify the output file**
+
+```bash
+wc -c docs/schema/resource.schema.json
+```
+
+Expected: > 5000 bytes (the schema is comprehensive).
+
+- [ ] **Step 5: Add schema reference to `docs/llm-guide.md`**
+
+Add this line at the top of `docs/llm-guide.md`, after the first paragraph:
+
+```markdown
+**IDE validation:** Add `# yaml-language-server: $schema=https://shaperail.dev/schema/resource.schema.json` to any resource YAML file for inline validation.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/schema/resource.schema.json docs/llm-guide.md
+git commit -m "docs: publish resource JSON Schema for IDE and LLM YAML validation"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- Pillar 1 (llm-guide + doc audit): Tasks 1 + 4 ✓
+- Pillar 2 (machine-readable artifacts — REFERENCE.md): Task 2 ✓
+- Pillar 2 (check --json fix fields): Already implemented in `Diagnostic` struct — no task needed ✓
+- Pillar 2 (JSON Schema audit + publish): Task 5 ✓
+- Pillar 3 (llm-context command): Task 3 ✓
+
+**Type consistency:**
+- `db_summary(config: &ProjectConfig) -> String` — used in both `print_markdown` and `print_json` ✓
+- `auth_summary(config: &ProjectConfig) -> String` — same ✓
+- `RelationType::BelongsTo/HasMany/HasOne` — imported from `shaperail_core` ✓
+- `shaperail_codegen::diagnostics::Diagnostic` — the `fix` field is `String`, `code` is `&'static str` ✓
+- `ep.auth.as_ref().map(|a| format!("{a}"))` — matches `explain.rs` pattern for `AuthRule` Display ✓
+
+**Placeholder check:** None found — all steps include exact code or exact commands.

--- a/docs/superpowers/specs/2026-04-20-llm-first-dx-design.md
+++ b/docs/superpowers/specs/2026-04-20-llm-first-dx-design.md
@@ -1,0 +1,199 @@
+# LLM-First Developer Experience Initiative
+**Date:** 2026-04-20  
+**Status:** Approved  
+**Scope:** Full initiative — doc audit, machine-readable artifacts, CLI command
+
+---
+
+## Goal
+
+An AI model (Claude, ChatGPT, etc.) working in Shaperail should:
+1. Start from a single ~300-line context file and generate valid resource YAML + controllers on the first try
+2. On an existing project, run one command to understand the full project state in ~50 lines
+3. Self-correct from CLI errors without needing additional documentation
+
+---
+
+## Current State
+
+- Framework: v0.7.0, M01–M19 complete, production-ready
+- 38 user docs exist — comprehensive but optimized for humans, not LLMs
+- `shaperail check --json` emits structured errors but no `fix:` guidance
+- No single canonical reference file for LLM consumption
+- No project-aware context dump command
+
+---
+
+## Pillar 1: LLM Guide + Doc Audit
+
+### New File: `docs/llm-guide.md`
+
+A single file (~300 lines) that is the *only* context an LLM needs to start building. Structure:
+
+1. **Resource YAML reference** — every field type (`uuid`, `string`, `integer`, `float`, `boolean`, `timestamp`, `enum`, `json`), every valid option per type (`primary`, `generated`, `required`, `unique`, `min`, `max`, `format`, `values`, `default`, `ref`). Dense, no prose. One canonical form shown — no alternatives.
+
+2. **Endpoint reference** — all endpoint types (`list`, `create`, `update`, `delete`, and custom) with every valid key per type:
+   - `list`: `auth`, `filters`, `search`, `pagination`, `cache`, `sort`
+   - `create`: `auth`, `input`, `controller`, `events`, `jobs`
+   - `update`: `auth`, `input`, `controller`
+   - `delete`: `auth`, `soft_delete`, `controller`
+   - custom: `method`, `path`, `auth`, `input`, `controller`
+
+3. **Controller API** — `ControllerContext` struct fields, `before`/`after` return types, a complete working template for a `create` controller with before-validation and after-event patterns.
+
+4. **Relations + indexes** — exact syntax for `belongs_to`, `has_many`, `has_one`; composite index syntax.
+
+5. **Do's and Don'ts** — 10 hard rules:
+   - Use `resource:` not `name:`
+   - `enum` requires `values:` array
+   - `soft_delete: true` requires a `deleted_at: { type: timestamp, generated: true }` field
+   - `ref:` must be in `resource.field` format
+   - `pagination:` must be `cursor` or `offset`
+   - Version drives route prefix: `version: 1` → `/v1/...`
+   - `input:` lists field names, not field definitions
+   - `auth:` takes role names from your auth config, not arbitrary strings
+   - `controller:` path is relative to the resource file, no `.rs` extension needed
+   - Relations do not auto-create foreign key constraints — declare the field explicitly in `schema:`
+
+6. **Error code table** — SR001–SR072, one line each: trigger condition + fix. This is the LLM's repair manual.
+
+### Doc Audit
+
+Scan all 38 docs in `docs/` for:
+- Multiple equivalent syntaxes for the same concept → remove all but the canonical one
+- Implicit behavior described without showing the YAML that enables it → add explicit YAML
+- Field names that differ from `resource-format.md` (source of truth) → fix to match
+- Docs that contradict each other → fix and add cross-reference
+- Any "you can also..." or "alternatively..." phrasing → remove the alternative
+
+Fix in-place. No new doc files for audit fixes.
+
+---
+
+## Pillar 2: Machine-Readable Artifacts
+
+### Enhanced `shaperail check --json`
+
+Add a `fix` field to every error object:
+
+```json
+{
+  "file": "resources/users.yaml",
+  "errors": [
+    {
+      "code": "SR024",
+      "field": "schema.role",
+      "message": "field 'role' is type enum but has no values",
+      "fix": "Add values array: { type: enum, values: [admin, member, viewer] }",
+      "doc": "https://shaperail.dev/docs/fields#enum"
+    }
+  ]
+}
+```
+
+Every error code in the validator must have a corresponding `fix` string. No error exits without a fix suggestion.
+
+### New File: `docs/REFERENCE.md`
+
+A machine-optimized reference card (~100 lines, no prose):
+- All field types and their valid keys (table format)
+- All endpoint types and their valid keys (table format)
+- All relation types and required keys
+- Config file keys (`shaperail.config.yaml`)
+- All CLI commands with flags
+- Complete error code table (SR001–SR072): code, trigger, fix
+
+This is the quick-lookup companion to `llm-guide.md`. The guide teaches patterns; the reference answers "what keys are valid here?"
+
+### JSON Schema (Existing — Enhance)
+
+`shaperail export json-schema` already works. Ensure:
+- Schema covers 100% of resource YAML fields (audit for gaps)
+- Schema is published to `docs/schema/resource.schema.json` and committed
+- README and `llm-guide.md` reference it so IDEs auto-validate resource files
+
+---
+
+## Pillar 3: `shaperail llm-context` CLI Command
+
+### Purpose
+
+An LLM joining an existing Shaperail project currently needs to read 10–20 files to understand the project state. This command dumps a minimal, accurate summary in ~50–100 lines.
+
+### Usage
+
+```bash
+shaperail llm-context                    # full project summary
+shaperail llm-context --resource users   # single resource deep-dive
+shaperail llm-context --format json      # machine-readable JSON
+```
+
+### Markdown Output (default)
+
+```
+# Project: my-app (v1.0.0)
+Database: postgres | Auth: jwt | Tenancy: disabled
+
+## Resources (3)
+
+### users (v1)
+Fields: id(uuid,pk), email(string,unique), name(string), role(enum:[admin,member]), org_id(uuid,fk→organizations.id), created_at, updated_at
+Endpoints: list[member,admin], create[admin], update[admin,owner], delete[admin]
+Relations: organization(belongs_to), orders(has_many)
+Cache: list(60s)
+Jobs: send_welcome_email on create
+
+### organizations (v1)
+Fields: id(uuid,pk), name(string), plan(enum:[free,pro,enterprise]), created_at
+Endpoints: list[admin], create[admin], update[admin], delete[admin]
+Relations: members(has_many→users)
+
+### orders (v1)
+Fields: id(uuid,pk), user_id(uuid,fk→users.id), total(float), status(enum:[pending,paid,cancelled]), created_at
+Endpoints: list[member,admin], create[member], update[admin]
+Relations: user(belongs_to)
+
+## Validation
+✓ No errors found
+```
+
+### JSON Output (`--format json`)
+
+Structured version of the same data — used when an LLM needs to parse the output programmatically or insert it into a system prompt.
+
+### Implementation Notes
+
+- Lives in `shaperail-cli/src/commands/llm_context.rs`
+- Reads resource YAML files via existing parser — no new parsing logic
+- Runs `shaperail check` logic inline to include validation status
+- `--resource` flag filters to one resource and adds controller file path + snippet preview
+- Output must be deterministic (sorted by resource name)
+
+---
+
+## Implementation Order
+
+1. **`docs/llm-guide.md`** — highest leverage, can be tested immediately by prompting an LLM
+2. **`docs/REFERENCE.md`** — quick win, pure writing
+3. **`shaperail check --json` fix fields** — requires touching validator + CLI (~50 lines of Rust)
+4. **`shaperail llm-context` command** — new CLI command, uses existing parser
+5. **Doc audit** — systematic pass over 38 docs, lowest urgency but important for consistency
+6. **JSON Schema audit** — verify coverage, publish to docs/
+
+---
+
+## Success Criteria
+
+- An LLM given only `llm-guide.md` generates a valid, compilable resource + controller on the first attempt for ≥90% of common patterns
+- `shaperail check --json` returns a `fix` field for every error code (SR001–SR072)
+- `shaperail llm-context` output fits in ≤150 lines for a 5-resource project
+- Doc audit eliminates all "alternatively" / "you can also" phrasing from user docs
+- JSON Schema validates 100% of fields in `resource-format.md`
+
+---
+
+## Out of Scope
+
+- M20 (Embedded AI + Admin Panel) — separate milestone
+- gRPC Update RPC — separate bugfix
+- New framework features — this initiative is purely DX/documentation/tooling

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -545,8 +545,8 @@ Load a specific seed file:
 shaperail seed seeds/users.yaml
 ```
 
-For tests, you can also insert data programmatically using the test helpers
-shown in the integration test examples above.
+For tests, insert data programmatically using the test helpers shown in the
+integration test examples above.
 
 ### Test data builder pattern
 

--- a/resources/users.yaml
+++ b/resources/users.yaml
@@ -15,6 +15,7 @@ schema:
   metadata:   { type: json, nullable: true }
   created_at: { type: timestamp, generated: true }
   updated_at: { type: timestamp, generated: true }
+  deleted_at: { type: timestamp, nullable: true }
 
 endpoints:
   list:

--- a/shaperail-cli/src/commands/check.rs
+++ b/shaperail-cli/src/commands/check.rs
@@ -73,10 +73,13 @@ pub fn run(path: &Path, json_output: bool) -> i32 {
     }
 
     if json_output {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&all_diagnostics).unwrap_or_else(|_| "[]".to_string())
-        );
+        match serde_json::to_string_pretty(&all_diagnostics) {
+            Ok(json) => println!("{json}"),
+            Err(e) => {
+                eprintln!("JSON serialization failed: {e}");
+                return 1;
+            }
+        }
     }
 
     if has_errors {

--- a/shaperail-cli/src/commands/llm_context.rs
+++ b/shaperail-cli/src/commands/llm_context.rs
@@ -37,7 +37,10 @@ pub fn run(resource_filter: Option<&str>, json_output: bool) -> i32 {
         .collect();
 
     if json_output {
-        print_json(&config, &filtered, &all_diags);
+        if let Err(e) = print_json(&config, &filtered, &all_diags) {
+            eprintln!("{e}");
+            return 1;
+        }
     } else {
         print_markdown(&config, &filtered, &all_diags);
     }
@@ -48,7 +51,12 @@ fn db_summary(config: &ProjectConfig) -> String {
     if let Some(ref dbs) = config.databases {
         let mut engines: Vec<String> = dbs
             .values()
-            .map(|d| format!("{:?}", d.engine).to_lowercase())
+            .map(|d| {
+                serde_json::to_value(d.engine)
+                    .ok()
+                    .and_then(|v| v.as_str().map(str::to_owned))
+                    .unwrap_or_else(|| format!("{:?}", d.engine).to_lowercase())
+            })
             .collect();
         engines.sort();
         engines.dedup();
@@ -218,7 +226,7 @@ fn print_json(
     config: &ProjectConfig,
     resources: &[&shaperail_core::ResourceDefinition],
     diags: &[(String, shaperail_codegen::diagnostics::Diagnostic)],
-) {
+) -> Result<(), String> {
     let resource_list: Vec<serde_json::Value> = resources
         .iter()
         .map(|rd| {
@@ -320,7 +328,10 @@ fn print_json(
         },
     });
 
-    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    let s = serde_json::to_string_pretty(&output)
+        .map_err(|e| format!("JSON serialization failed: {e}"))?;
+    println!("{s}");
+    Ok(())
 }
 
 #[cfg(test)]

--- a/shaperail-cli/src/commands/llm_context.rs
+++ b/shaperail-cli/src/commands/llm_context.rs
@@ -1,0 +1,378 @@
+use shaperail_core::{ProjectConfig, RelationType};
+
+pub fn run(resource_filter: Option<&str>, json_output: bool) -> i32 {
+    let config = match super::load_config() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let resources = match super::load_all_resources() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let mut filtered: Vec<_> = resources.iter().collect();
+    if let Some(name) = resource_filter {
+        filtered.retain(|r| r.resource == name);
+        if filtered.is_empty() {
+            eprintln!("No resource named '{name}' found in resources/");
+            return 1;
+        }
+    }
+    filtered.sort_by(|a, b| a.resource.cmp(&b.resource));
+
+    let all_diags: Vec<_> = filtered
+        .iter()
+        .flat_map(|r| {
+            shaperail_codegen::diagnostics::diagnose_resource(r)
+                .into_iter()
+                .map(|d| (r.resource.clone(), d))
+        })
+        .collect();
+
+    if json_output {
+        print_json(&config, &filtered, &all_diags);
+    } else {
+        print_markdown(&config, &filtered, &all_diags);
+    }
+    0
+}
+
+fn db_summary(config: &ProjectConfig) -> String {
+    if let Some(ref dbs) = config.databases {
+        let mut engines: Vec<String> = dbs
+            .values()
+            .map(|d| format!("{:?}", d.engine).to_lowercase())
+            .collect();
+        engines.sort();
+        engines.dedup();
+        engines.join(", ")
+    } else if let Some(ref db) = config.database {
+        db.db_type.clone()
+    } else {
+        "unknown".into()
+    }
+}
+
+fn auth_summary(config: &ProjectConfig) -> String {
+    config
+        .auth
+        .as_ref()
+        .map(|a| a.provider.clone())
+        .unwrap_or_else(|| "none".into())
+}
+
+fn print_markdown(
+    config: &ProjectConfig,
+    resources: &[&shaperail_core::ResourceDefinition],
+    diags: &[(String, shaperail_codegen::diagnostics::Diagnostic)],
+) {
+    println!("# Project: {}", config.project);
+    println!(
+        "Database: {} | Auth: {} | Port: {}",
+        db_summary(config),
+        auth_summary(config),
+        config.port
+    );
+    println!();
+    println!("## Resources ({})", resources.len());
+    println!();
+
+    for rd in resources {
+        println!("### {} (v{})", rd.resource, rd.version);
+
+        let field_strs: Vec<String> = rd
+            .schema
+            .iter()
+            .map(|(name, field)| {
+                let mut parts = vec![field.field_type.to_string()];
+                if field.primary {
+                    parts.push("pk".into());
+                }
+                if field.generated {
+                    parts.push("generated".into());
+                }
+                if field.required {
+                    parts.push("required".into());
+                }
+                if field.unique {
+                    parts.push("unique".into());
+                }
+                if let Some(ref r) = field.reference {
+                    parts.push(format!("fk→{r}"));
+                }
+                if let Some(ref vals) = field.values {
+                    parts.push(format!("[{}]", vals.join(",")));
+                }
+                if let Some(ref def) = field.default {
+                    parts.push(format!("default:{def}"));
+                }
+                format!("{name}({})", parts.join(","))
+            })
+            .collect();
+        println!("Fields: {}", field_strs.join(", "));
+
+        if let Some(ref eps) = rd.endpoints {
+            let mut ep_list: Vec<(String, String)> = eps
+                .iter()
+                .map(|(action, ep)| {
+                    let auth_str = match &ep.auth {
+                        Some(a) => format!("{a}"),
+                        None => "none".into(),
+                    };
+                    (action.clone(), format!("{action}[{auth_str}]"))
+                })
+                .collect();
+            ep_list.sort_by(|a, b| a.0.cmp(&b.0));
+            println!(
+                "Endpoints: {}",
+                ep_list
+                    .iter()
+                    .map(|(_, s)| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        if let Some(ref rels) = rd.relations {
+            let mut rel_list: Vec<(String, String)> = rels
+                .iter()
+                .map(|(name, rel)| {
+                    let kind = match rel.relation_type {
+                        RelationType::BelongsTo => "belongs_to",
+                        RelationType::HasMany => "has_many",
+                        RelationType::HasOne => "has_one",
+                    };
+                    (name.clone(), format!("{name}({kind}→{})", rel.resource))
+                })
+                .collect();
+            rel_list.sort_by(|a, b| a.0.cmp(&b.0));
+            println!(
+                "Relations: {}",
+                rel_list
+                    .iter()
+                    .map(|(_, s)| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        if let Some(ref eps) = rd.endpoints {
+            let mut cached: Vec<String> = eps
+                .iter()
+                .filter_map(|(action, ep)| {
+                    ep.cache.as_ref().map(|c| format!("{action}({}s)", c.ttl))
+                })
+                .collect();
+            if !cached.is_empty() {
+                cached.sort();
+                println!("Cache: {}", cached.join(", "));
+            }
+        }
+
+        if let Some(ref tk) = rd.tenant_key {
+            println!("Tenant key: {tk}");
+        }
+
+        let has_soft_delete = rd
+            .endpoints
+            .as_ref()
+            .map(|eps| eps.values().any(|ep| ep.soft_delete))
+            .unwrap_or(false);
+        if has_soft_delete {
+            println!("Soft delete: enabled");
+        }
+
+        let res_diags: Vec<_> = diags.iter().filter(|(r, _)| r == &rd.resource).collect();
+        if !res_diags.is_empty() {
+            println!(
+                "Errors: {}",
+                res_diags
+                    .iter()
+                    .map(|(_, d)| format!("[{}] {}", d.code, d.error))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
+        }
+
+        println!();
+    }
+
+    if diags.is_empty() {
+        println!("## Validation\n✓ No errors found");
+    } else {
+        println!("## Validation\n⚠ {} issue(s):", diags.len());
+        for (resource, d) in diags {
+            println!("  {resource} [{}] {} → {}", d.code, d.error, d.fix);
+        }
+    }
+}
+
+fn print_json(
+    config: &ProjectConfig,
+    resources: &[&shaperail_core::ResourceDefinition],
+    diags: &[(String, shaperail_codegen::diagnostics::Diagnostic)],
+) {
+    let resource_list: Vec<serde_json::Value> = resources
+        .iter()
+        .map(|rd| {
+            let fields: Vec<serde_json::Value> = rd
+                .schema
+                .iter()
+                .map(|(name, field)| {
+                    serde_json::json!({
+                        "name": name,
+                        "type": field.field_type.to_string(),
+                        "primary": field.primary,
+                        "generated": field.generated,
+                        "required": field.required,
+                        "unique": field.unique,
+                        "ref": field.reference,
+                        "values": field.values,
+                        "default": field.default,
+                    })
+                })
+                .collect();
+
+            let endpoints: Vec<serde_json::Value> = rd
+                .endpoints
+                .as_ref()
+                .map(|eps| {
+                    eps.iter()
+                        .map(|(action, ep)| {
+                            serde_json::json!({
+                                "action": action,
+                                "method": ep.method(),
+                                "path": format!("/v{}{}", rd.version, ep.path()),
+                                "auth": ep.auth.as_ref().map(|a| format!("{a}")),
+                                "cache_ttl": ep.cache.as_ref().map(|c| c.ttl),
+                                "soft_delete": ep.soft_delete,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let relations: Vec<serde_json::Value> = rd
+                .relations
+                .as_ref()
+                .map(|rels| {
+                    rels.iter()
+                        .map(|(name, rel)| {
+                            let kind = match rel.relation_type {
+                                RelationType::BelongsTo => "belongs_to",
+                                RelationType::HasMany => "has_many",
+                                RelationType::HasOne => "has_one",
+                            };
+                            serde_json::json!({
+                                "name": name,
+                                "type": kind,
+                                "resource": rel.resource,
+                                "key": rel.key,
+                                "foreign_key": rel.foreign_key,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let errors: Vec<serde_json::Value> = diags
+                .iter()
+                .filter(|(r, _)| r == &rd.resource)
+                .map(|(_, d)| {
+                    serde_json::json!({
+                        "code": d.code,
+                        "error": d.error,
+                        "fix": d.fix,
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "name": rd.resource,
+                "version": rd.version,
+                "tenant_key": rd.tenant_key,
+                "fields": fields,
+                "endpoints": endpoints,
+                "relations": relations,
+                "errors": errors,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "project": {
+            "name": config.project,
+            "database": db_summary(config),
+            "auth": auth_summary(config),
+            "port": config.port,
+        },
+        "resources": resource_list,
+        "validation": {
+            "total_errors": diags.len(),
+            "clean": diags.is_empty(),
+        },
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shaperail_core::{DatabaseConfig, ProjectConfig, WorkerCount};
+
+    fn make_config(project: &str) -> ProjectConfig {
+        ProjectConfig {
+            project: project.to_string(),
+            port: 3000,
+            workers: WorkerCount::Auto,
+            database: Some(DatabaseConfig {
+                db_type: "postgresql".to_string(),
+                host: "localhost".to_string(),
+                port: 5432,
+                name: "test_db".to_string(),
+                pool_size: 5,
+            }),
+            databases: None,
+            cache: None,
+            auth: None,
+            storage: None,
+            logging: None,
+            events: None,
+            protocols: vec!["rest".to_string()],
+            graphql: None,
+            grpc: None,
+        }
+    }
+
+    #[test]
+    fn db_summary_single_db() {
+        let config = make_config("my-app");
+        assert_eq!(db_summary(&config), "postgresql");
+    }
+
+    #[test]
+    fn auth_summary_no_auth() {
+        let config = make_config("my-app");
+        assert_eq!(auth_summary(&config), "none");
+    }
+
+    #[test]
+    fn auth_summary_with_jwt() {
+        let mut config = make_config("my-app");
+        config.auth = Some(shaperail_core::AuthConfig {
+            provider: "jwt".to_string(),
+            secret_env: "JWT_SECRET".to_string(),
+            expiry: "24h".to_string(),
+            refresh_expiry: None,
+        });
+        assert_eq!(auth_summary(&config), "jwt");
+    }
+}

--- a/shaperail-cli/src/commands/mod.rs
+++ b/shaperail-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod export;
 pub mod generate;
 pub mod init;
 pub mod jobs_status;
+pub mod llm_context;
 pub mod migrate;
 pub mod resource;
 pub mod routes;

--- a/shaperail-cli/src/main.rs
+++ b/shaperail-cli/src/main.rs
@@ -97,6 +97,16 @@ enum Commands {
         /// Optional job ID to inspect
         job_id: Option<String>,
     },
+    /// Dump a project-aware context summary for LLM consumption
+    #[command(name = "llm-context")]
+    LlmContext {
+        /// Filter to a single resource by name
+        #[arg(short, long)]
+        resource: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Manage resource files
     Resource {
         #[command(subcommand)]
@@ -178,6 +188,9 @@ fn main() {
         Commands::Doctor => commands::doctor::run(),
         Commands::Routes => commands::routes::run(),
         Commands::JobsStatus { job_id } => commands::jobs_status::run(job_id.as_deref()),
+        Commands::LlmContext { resource, json } => {
+            commands::llm_context::run(resource.as_deref(), json)
+        }
         Commands::Resource { action } => match action {
             ResourceAction::Create { name, archetype } => {
                 commands::resource::run_create(&name, &archetype)

--- a/shaperail-codegen/src/diagnostics.rs
+++ b/shaperail-codegen/src/diagnostics.rs
@@ -270,14 +270,14 @@ pub fn diagnose_resource(rd: &ResourceDefinition) -> Vec<Diagnostic> {
                 }
             }
 
-            if ep.soft_delete && !rd.schema.contains_key("updated_at") {
+            if ep.soft_delete && !rd.schema.contains_key("deleted_at") {
                 diags.push(Diagnostic {
                     code: "SR041",
                     error: format!(
-                        "resource '{res}': endpoint '{action}' has soft_delete but schema has no 'updated_at' field"
+                        "resource '{res}': endpoint '{action}' has soft_delete but schema has no 'deleted_at' field"
                     ),
-                    fix: "add an 'updated_at' timestamp field to the schema".into(),
-                    example: "updated_at: { type: timestamp, generated: true }".into(),
+                    fix: "add 'deleted_at: { type: timestamp, nullable: true }' to the schema".into(),
+                    example: "deleted_at: { type: timestamp, nullable: true }".into(),
                 });
             }
 

--- a/shaperail-codegen/src/json_schema.rs
+++ b/shaperail-codegen/src/json_schema.rs
@@ -220,7 +220,6 @@ pub fn generate_resource_json_schema() -> Value {
             "EndpointSpec": {
                 "type": "object",
                 "description": "Specification for a single endpoint in a resource.",
-                "required": ["method", "path"],
                 "additionalProperties": false,
                 "properties": {
                     "method": { "$ref": "#/$defs/HttpMethod" },
@@ -267,7 +266,7 @@ pub fn generate_resource_json_schema() -> Value {
                     "soft_delete": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Whether this endpoint performs a soft delete. Requires an 'updated_at' field in schema."
+                        "description": "Whether this endpoint performs a soft delete. Requires a 'deleted_at' nullable timestamp field in schema."
                     }
                 }
             },

--- a/shaperail-codegen/src/parser.rs
+++ b/shaperail-codegen/src/parser.rs
@@ -70,7 +70,7 @@ schema:
         let rd = parse_resource(yaml).unwrap();
         assert_eq!(rd.resource, "users");
         assert_eq!(rd.version, 1);
-        assert_eq!(rd.schema.len(), 9);
+        assert_eq!(rd.schema.len(), 10);
         assert!(rd.endpoints.is_some());
         assert!(rd.relations.is_some());
         assert!(rd.indexes.is_some());

--- a/shaperail-runtime/Cargo.toml
+++ b/shaperail-runtime/Cargo.toml
@@ -38,7 +38,7 @@ indexmap = { workspace = true, features = ["serde"] }
 jsonwebtoken = { workspace = true }
 deadpool-redis = { workspace = true }
 redis = { workspace = true }
-sha2 = "0.11"
+sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
 futures-util = "0.3"

--- a/shaperail-runtime/src/grpc/server.rs
+++ b/shaperail-runtime/src/grpc/server.rs
@@ -6,7 +6,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use http_body_util::BodyExt;
 use prost::bytes::Bytes;
 use shaperail_core::{GrpcConfig, ResourceDefinition};
 use tokio::task::JoinHandle;
@@ -105,8 +104,7 @@ enum GrpcResponse {
     Stream(Vec<Bytes>),
 }
 
-/// The tonic body type used in 0.12.
-type TonicBody = tonic::body::BoxBody;
+type TonicBody = tonic::body::Body;
 
 /// Wrapper implementing tonic's Service trait for dynamic dispatch.
 #[derive(Clone)]
@@ -220,9 +218,7 @@ fn grpc_data_response(data: &[u8]) -> http::Response<TonicBody> {
     frame.extend_from_slice(&len.to_be_bytes());
     frame.extend_from_slice(data);
 
-    let body = http_body_util::Full::new(Bytes::from(frame))
-        .map_err(|never: std::convert::Infallible| match never {});
-    let boxed = TonicBody::new(body);
+    let boxed = TonicBody::new(http_body_util::Full::new(Bytes::from(frame)));
 
     http::Response::builder()
         .status(200)
@@ -239,9 +235,7 @@ fn grpc_error_response(code: tonic::Code, message: &str) -> http::Response<Tonic
 
 /// Build an empty gRPC response with status and message headers.
 fn empty_grpc_response(code: i32, message: &str) -> http::Response<TonicBody> {
-    let body = http_body_util::Full::new(Bytes::new())
-        .map_err(|never: std::convert::Infallible| match never {});
-    let boxed = TonicBody::new(body);
+    let boxed = TonicBody::new(http_body_util::Full::new(Bytes::new()));
 
     http::Response::builder()
         .status(200)
@@ -250,10 +244,7 @@ fn empty_grpc_response(code: i32, message: &str) -> http::Response<TonicBody> {
         .header("grpc-message", message)
         .body(boxed)
         .unwrap_or_else(|_| {
-            // Last resort fallback
-            let fb = http_body_util::Full::new(Bytes::new())
-                .map_err(|never: std::convert::Infallible| match never {});
-            http::Response::new(TonicBody::new(fb))
+            http::Response::new(TonicBody::new(http_body_util::Full::new(Bytes::new())))
         })
 }
 
@@ -276,7 +267,7 @@ pub async fn build_grpc_server(
     let grpc_service = ShaperailGrpcServiceServer { inner: svc };
 
     // Health service
-    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+    let (health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter
         .set_serving::<ShaperailGrpcServiceServer>()
         .await;


### PR DESCRIPTION
## Summary

- **`docs/llm-guide.md`** — single-file, ~360-line context that an AI model loads once to build in Shaperail without any other docs; covers resource format, field types, endpoints, controller pattern, relations, indexes, do's and don'ts, common patterns, SR001–SR072 error codes, and CLI reference
- **`docs/llm-reference.md`** — 119-line machine-optimized quick-lookup tables (field types, endpoint keys by type, relation types, config keys, CLI commands, archetypes, error codes)
- **`shaperail llm-context` CLI command** — dumps a project-aware summary (resources, fields, endpoints, relations, validation errors) in ~50–100 lines for brownfield use; supports `--resource <name>` filter and `--format --json` output
- **`docs/schema/resource.schema.json`** — published 12KB JSON Schema for IDE inline validation of resource YAML files
- **Doc audit** — removed "alternatively"/"you can also" phrasing from 4 docs, fixed 5 `soft_delete` examples missing `deleted_at` field in schema, fixed resource-guide.md canonical endpoint syntax
- **Bug fixes** — SR041 diagnostic now checks `deleted_at` (not `updated_at`), JSON Schema no longer marks `method`/`path` as required on endpoints, `check.rs` and `llm_context.rs` no longer silently swallow JSON serialization errors, `format` valid values aligned to canonical `email|url|uuid`

## Test Plan

- [ ] `cargo test --workspace` — 470 unit/library tests pass (24 integration tests require `docker compose up -d`, pre-existing)
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `shaperail llm-context` runs without error in a project directory
- [ ] `shaperail check --json` includes `fix` field on every error
- [ ] Load `docs/llm-guide.md` into Claude/ChatGPT and ask it to generate a resource — verify it produces valid YAML on the first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)