### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
Potential fix for [https://github.com/shaperail/shaperail/security/code-scanning/1](https://github.com/shaperail/shaperail/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml`, right after the `on:` section (or before `jobs:`), so it applies to all jobs (`check`, `test`, `audit`) consistently.

Best single fix (minimal and non-breaking): set:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI tasks shown here. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
