### PR TITLE
docs: public documentation overhaul — clarity, nav, feature tiers

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-nav_order: 4
+nav_order: 5
 has_children: true
 permalink: /examples/
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,6 @@
 ---
 title: Getting started
-parent: Guides
-nav_order: 1
+nav_order: 2
 ---
 
 This guide gets you from zero to a running Shaperail service with browser docs,

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,6 +1,6 @@
 ---
 title: Guides
-nav_order: 2
+nav_order: 3
 has_children: true
 permalink: /guides/
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,20 +83,35 @@ Generated Rust, OpenAPI, and routes live in `generated/` and are not hand-edited
 
 ## Features at a glance
 
-- **REST API** — List, get, create, update, delete, bulk create/delete; cursor or offset pagination; filters, sort, full-text search; field selection and relation loading (`?include=…`).
-- **GraphQL** — Enable with `protocols: [rest, graphql]`. The current generated schema exposes `list_<resource>`, singular get-by-id fields, and `create_` / `update_` / `delete_` mutations. List fields currently support `limit` and `offset` only.
-- **gRPC** — Enable with `protocols: [rest, grpc]`. The current server supports list, stream, get, create, and delete RPCs plus health/reflection. `Update` is not implemented yet, and the CLI does not currently write `.proto` files to disk.
-- **Multi-database** — Optional `databases:` in config with named connections (e.g. `default`, `analytics`). Per-resource `db:` routes that resource to a connection; migrations run against `default`.
-- **API versioning** — Per-resource `version` field prefixes all routes (`/v1/users`, `/v2/orders`). OpenAPI spec and CLI output reflect versioned paths.
-- **Controllers** — Synchronous before/after business logic on write endpoints. Validate input, normalize data, enrich responses — in Rust or sandboxed WASM (TypeScript, Python, Rust, etc.).
-- **Auth** — JWT auth is scaffolded from `JWT_SECRET`. API key auth and Redis-backed rate limiting exist as runtime primitives but require manual wiring in the generated app.
-- **Caching** — Redis-backed cache per GET endpoint with TTL and configurable invalidation.
-- **Background jobs** — Endpoint `jobs:` declarations enqueue work into the Redis queue. Running a worker and registering handlers is still a manual bootstrap step.
-- **WebSockets** — Runtime session/channel primitives exist, but the scaffold does not auto-load `channels/*.channel.yaml` or register `/ws/...` routes.
-- **File storage** — Local, S3, GCS, Azure; upload validation, signed URLs, image processing.
-- **Events & webhooks** — Write handlers can emit events into the job queue. Subscriber execution, webhook delivery handlers, and inbound webhook route registration still require manual wiring.
-- **Observability** — Structured JSON logs, request_id, PII redaction; Prometheus metrics; OpenTelemetry; `/health` and `/health/ready`.
-- **Multi-service workspaces** — `shaperail serve --workspace` validates a workspace and starts each service in dependency order. Registry, typed clients, and saga orchestration are not wired into that flow yet.
-- **Multi-tenancy** — Add `tenant_key: org_id` to any resource for automatic row-level isolation. Queries are scoped to the JWT `tenant_id` claim; cache keys are per-tenant; rate-limit keys are too when the limiter is wired; `super_admin` bypasses the filter.
-- **WASM plugins** — Write controller hooks in TypeScript, Python, Rust, or any language that compiles to WASM. Sandboxed execution with no filesystem or network access; fuel-limited; crash-isolated from the server.
-- **OpenAPI & SDK** — Deterministic OpenAPI 3.1; TypeScript SDK generation.
+### Production-ready today
+
+Everything below works from a resource YAML file with no manual wiring.
+
+- **REST API** — List, get, create, update, delete, bulk create/delete; cursor and offset pagination; filters, sort, full-text search; field selection; relation loading (`?include=`)
+- **Authentication** — JWT auth; role-based and owner-based access control declared per endpoint
+- **Caching** — Redis-backed cache per GET endpoint with TTL, auto-invalidation on writes, configurable `invalidate_on`
+- **File storage** — Local, S3, GCS, Azure; upload validation, signed URLs, image processing
+- **Multi-tenancy** — Row-level isolation via `tenant_key`; per-tenant cache and rate-limit keys; `super_admin` bypass
+- **Observability** — Structured JSON logs, request_id propagation, Prometheus metrics, health endpoints (`/health`, `/health/ready`), OpenTelemetry trace export
+- **Migrations** — Initial create-table SQL generated from schema; sqlx compile-time verified
+- **OpenAPI 3.1** — Deterministic spec generation; TypeScript SDK generation
+- **WASM plugins** — Controller hooks in TypeScript, Python, Rust, or any WASM-targeting language; sandboxed, fuel-limited, crash-isolated
+
+### Available — requires manual wiring
+
+The runtime primitives exist and are documented. Connecting them requires code in your `main.rs` or config. Each linked guide explains exactly what to wire.
+
+- **Background jobs** — Queue and worker primitives; worker registration and handler mapping are manual ([Background jobs](/background-jobs/))
+- **Events and webhooks** — Event emission from write handlers works; subscriber execution and inbound route registration are manual ([Events and webhooks](/events-and-webhooks/))
+- **WebSockets** — Session and channel primitives work; route registration is manual ([WebSockets](/websockets/))
+- **API key auth and rate limiting** — Runtime primitives exist; wiring to endpoints is manual ([Auth and ownership](/auth-and-ownership/))
+- **GraphQL** — Enable with `protocols: [rest, graphql]`; generates list/get queries and create/update/delete mutations; list queries support `limit`/`offset` only ([GraphQL](/graphql/))
+- **gRPC** — Enable with `protocols: [rest, grpc]`; supports list, stream, get, create, delete; `Update` RPC is not yet implemented ([gRPC](/grpc/))
+
+### In progress
+
+- gRPC Update RPC
+- WebSocket auto-routing from channel YAML files
+- Events subscriber auto-execution
+- Workspace service registry and saga orchestration
+- Background job worker auto-registration

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ nav_order: 1
 
 # Shaperail
 
-**An AI-native Rust backend framework.** Define resources in YAML; get a production-ready REST API plus optional protocol and async primitives from one canonical schema.
+**Define your API as YAML resources. Shaperail generates the Rust backend — routes, database schema, validation, auth, migrations, and OpenAPI — from that one file.**
 
 *Documentation for v{{ site.release_version }}.*
 
@@ -37,6 +37,8 @@ Your app is available at:
 
 ## Why Shaperail
 
+A typical REST resource in plain Rust spans handler files, database models, migration SQL, validation logic, auth middleware, and OpenAPI annotations — 300–500 lines across 5 or more files. Add another resource, repeat the work. Shaperail replaces all of that with one ~40-line YAML file. The framework reads the file and generates the Rust code, the SQL schema, and the OpenAPI spec deterministically.
+
 | Principle | What it means |
 | --- | --- |
 | **One source of truth** | Resource YAML drives schema, routes, validation, migrations, and OpenAPI. No hidden conventions. |
@@ -45,7 +47,7 @@ Your app is available at:
 | **Deterministic output** | Same resource files produce the same OpenAPI spec and code every time. |
 | **Docker-first dev** | `docker compose up -d` gives you Postgres and Redis; no manual DB setup. |
 
-The framework is built so that docs, codegen, and runtime stay in sync — and so that LLMs can generate valid Shaperail resources and commands with minimal mistakes.
+> Working with an LLM? Load [llm-guide.md](/llm-guide/) as context — it is the sole file an AI assistant needs to generate valid Shaperail resources.
 
 ---
 
@@ -69,7 +71,7 @@ You edit these files; the framework generates the rest.
 | File | Role |
 | --- | --- |
 | `resources/*.yaml` | Schema, endpoints, auth, relations, filters, pagination, cache, indexes |
-| `resources/*.controller.rs` | One workable convention for controller modules; current apps still require manual controller registration |
+| `resources/*.controller.rs` | Business logic before/after DB writes — see [Controllers](/controllers/) |
 | `migrations/*.sql` | SQL that evolves the database (initial create files can be generated; later schema changes are manual SQL today) |
 | `shaperail.config.yaml` | Port, database, cache, auth, storage, logging, event subscribers |
 | `.env` | `DATABASE_URL`, `REDIS_URL`, `JWT_SECRET`, etc. |
@@ -98,23 +100,3 @@ Generated Rust, OpenAPI, and routes live in `generated/` and are not hand-edited
 - **Multi-tenancy** — Add `tenant_key: org_id` to any resource for automatic row-level isolation. Queries are scoped to the JWT `tenant_id` claim; cache keys are per-tenant; rate-limit keys are too when the limiter is wired; `super_admin` bypasses the filter.
 - **WASM plugins** — Write controller hooks in TypeScript, Python, Rust, or any language that compiles to WASM. Sandboxed execution with no filesystem or network access; fuel-limited; crash-isolated from the server.
 - **OpenAPI & SDK** — Deterministic OpenAPI 3.1; TypeScript SDK generation.
-
----
-
-## Documentation map
-
-### Get going
-
-- [**Getting started**]({{ '/getting-started/' | relative_url }}) — Install CLI, scaffold a project, run the app, first schema change.
-
-### Guides
-
-- [**Guides**]({{ '/guides/' | relative_url }}) — Auth, controllers, migrations, Docker, caching, jobs, WebSockets, file storage, events, observability, GraphQL.
-
-### Reference
-
-- [**Reference**]({{ '/reference/' | relative_url }}) — Resource format, configuration, CLI, API responses and query parameters.
-
-### Examples
-
-- [**Examples**]({{ '/examples/' | relative_url }}) — [Blog API example]({{ '/blog-api-example/' | relative_url }}) plus direct links to the checked-in repository examples for enterprise SaaS billing, an incident platform, multi-tenant SaaS, multi-service workspaces, and WASM plugins.

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,16 +95,19 @@ Everything below works from a resource YAML file with no manual wiring.
 - **Observability** — Structured JSON logs, request_id propagation, Prometheus metrics, health endpoints (`/health`, `/health/ready`), OpenTelemetry trace export
 - **Migrations** — Initial create-table SQL generated from schema; sqlx compile-time verified
 - **OpenAPI 3.1** — Deterministic spec generation; TypeScript SDK generation
-- **WASM plugins** — Controller hooks in TypeScript, Python, Rust, or any WASM-targeting language; sandboxed, fuel-limited, crash-isolated
+- **WASM plugins** — Sandboxed controller hooks declared directly in YAML via the `wasm:` path prefix; supports TypeScript, Python, Rust, and any WASM-targeting language; fuel-limited, crash-isolated
+- **API versioning** — Per-resource `version` field prefixes all routes (`/v1/users`, `/v2/orders`); reflected in OpenAPI spec and CLI output
+- **Multi-database** — Named database connections via `databases:` config; per-resource `db:` routing; migrations run against `default`
 
 ### Available — requires manual wiring
 
-The runtime primitives exist and are documented. Connecting them requires code in your `main.rs` or config. Each linked guide explains exactly what to wire.
+The runtime primitives exist and are documented. Background jobs, events, WebSockets, and API key auth require code in your `main.rs` to connect. GraphQL and gRPC are enabled via a `protocols:` config line but have known feature gaps listed below. Each linked guide explains what works today.
 
 - **Background jobs** — Queue and worker primitives; worker registration and handler mapping are manual ([Background jobs](/background-jobs/))
 - **Events and webhooks** — Event emission from write handlers works; subscriber execution and inbound route registration are manual ([Events and webhooks](/events-and-webhooks/))
 - **WebSockets** — Session and channel primitives work; route registration is manual ([WebSockets](/websockets/))
 - **API key auth and rate limiting** — Runtime primitives exist; wiring to endpoints is manual ([Auth and ownership](/auth-and-ownership/))
+- **Controllers (Rust)** — Before/after business logic on write endpoints; controller registration requires manual `main.rs` wiring ([Controllers](/controllers/))
 - **GraphQL** — Enable with `protocols: [rest, graphql]`; generates list/get queries and create/update/delete mutations; list queries support `limit`/`offset` only ([GraphQL](/graphql/))
 - **gRPC** — Enable with `protocols: [rest, grpc]`; supports list, stream, get, create, delete; `Update` RPC is not yet implemented ([gRPC](/grpc/))
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,23 +91,22 @@ Everything below works from a resource YAML file with no manual wiring.
 - **Authentication** — JWT auth; role-based and owner-based access control declared per endpoint
 - **Caching** — Redis-backed cache per GET endpoint with TTL, auto-invalidation on writes, configurable `invalidate_on`
 - **File storage** — Local, S3, GCS, Azure; upload validation, signed URLs, image processing
-- **Multi-tenancy** — Row-level isolation via `tenant_key`; per-tenant cache and rate-limit keys; `super_admin` bypass
+- **Multi-tenancy** — Row-level isolation via `tenant_key`; per-tenant cache keys; `super_admin` bypass
 - **Observability** — Structured JSON logs, request_id propagation, Prometheus metrics, health endpoints (`/health`, `/health/ready`), OpenTelemetry trace export
 - **Migrations** — Initial create-table SQL generated from schema; sqlx compile-time verified
 - **OpenAPI 3.1** — Deterministic spec generation; TypeScript SDK generation
-- **WASM plugins** — Sandboxed controller hooks declared directly in YAML via the `wasm:` path prefix; supports TypeScript, Python, Rust, and any WASM-targeting language; fuel-limited, crash-isolated
 - **API versioning** — Per-resource `version` field prefixes all routes (`/v1/users`, `/v2/orders`); reflected in OpenAPI spec and CLI output
 - **Multi-database** — Named database connections via `databases:` config; per-resource `db:` routing; migrations run against `default`
 
 ### Available — requires manual wiring
 
-The runtime primitives exist and are documented. Background jobs, events, WebSockets, and API key auth require code in your `main.rs` to connect. GraphQL and gRPC are enabled via a `protocols:` config line but have known feature gaps listed below. Each linked guide explains what works today.
+The runtime primitives exist and are documented. Background jobs, events, WebSockets, and API key auth require code in your `main.rs` to connect. GraphQL and gRPC require a Cargo feature flag and a `protocols:` config line, and have known feature gaps listed below. Each linked guide explains what works today.
 
 - **Background jobs** — Queue and worker primitives; worker registration and handler mapping are manual ([Background jobs](/background-jobs/))
 - **Events and webhooks** — Event emission from write handlers works; subscriber execution and inbound route registration are manual ([Events and webhooks](/events-and-webhooks/))
 - **WebSockets** — Session and channel primitives work; route registration is manual ([WebSockets](/websockets/))
 - **API key auth and rate limiting** — Runtime primitives exist; wiring to endpoints is manual ([Auth and ownership](/auth-and-ownership/))
-- **Controllers (Rust)** — Before/after business logic on write endpoints; controller registration requires manual `main.rs` wiring ([Controllers](/controllers/))
+- **Controllers** — Before/after business logic on write endpoints in Rust or WASM (TypeScript, Python, Rust, Go, or any WASM-targeting language); controller registration requires manual `main.rs` wiring ([Controllers](/controllers/))
 - **GraphQL** — Enable with `protocols: [rest, graphql]`; generates list/get queries and create/update/delete mutations; list queries support `limit`/`offset` only ([GraphQL](/graphql/))
 - **gRPC** — Enable with `protocols: [rest, grpc]`; supports list, stream, get, create, delete; `Update` RPC is not yet implemented ([gRPC](/grpc/))
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ A typical REST resource in plain Rust spans handler files, database models, migr
 | **Deterministic output** | Same resource files produce the same OpenAPI spec and code every time. |
 | **Docker-first dev** | `docker compose up -d` gives you Postgres and Redis; no manual DB setup. |
 
-> Working with an LLM? Load [llm-guide.md](/llm-guide/) as context — it is the sole file an AI assistant needs to generate valid Shaperail resources.
+> Working with an LLM? Load the [LLM Guide](/llm-guide/) as context — it is the sole file an AI assistant needs to generate valid Shaperail resources.
 
 ---
 

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -1,3 +1,8 @@
+---
+title: Shaperail LLM Guide
+nav_exclude: true
+---
+
 # Shaperail LLM Guide
 
 Load this file as your sole context. You do not need other docs to build in Shaperail.

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -1,3 +1,8 @@
+---
+title: Shaperail Quick Reference
+nav_exclude: true
+---
+
 # Shaperail Quick Reference
 
 Terse lookup tables. For patterns and examples, see [llm-guide.md](llm-guide.md).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,6 +1,6 @@
 ---
 title: Reference
-nav_order: 3
+nav_order: 4
 has_children: true
 permalink: /reference/
 ---

--- a/docs/superpowers/specs/2026-04-20-docs-overhaul-design.md
+++ b/docs/superpowers/specs/2026-04-20-docs-overhaul-design.md
@@ -1,0 +1,157 @@
+# Documentation Overhaul Design — Approach B
+**Date:** 2026-04-20
+**Status:** Approved
+**Scope:** Homepage rewrite, feature tier split, nav cleanup
+
+---
+
+## Goal
+
+Make the public docs work equally well for two audiences:
+
+1. **Evaluators** — developers deciding whether to adopt Shaperail. They need to immediately understand the problem the framework solves, what is production-ready today, and what requires extra wiring.
+2. **Users** — developers already building with Shaperail. They need accurate, scannable reference material without noise from machine-targeted files or buried entry points.
+
+---
+
+## Problems Being Fixed
+
+### 1. The tagline doesn't explain the product
+"AI-native Rust backend framework" sounds like a framework that uses AI, not one designed for AI-assisted development. The actual pitch — write YAML, get a production-ready Rust REST API — is buried.
+
+### 2. "Why Shaperail" explains design principles, not pain
+The current table starts with "One source of truth / Explicit over implicit / Flat abstraction". These are architectural philosophy items. Evaluators need to understand the cost of NOT using Shaperail before they care about its design philosophy.
+
+### 3. Feature list conflates production-ready with in-progress
+Bullet items like "WebSockets — Runtime session/channel primitives exist, but the scaffold does not auto-load..." sit next to fully-working features with no visual distinction. Evaluators cannot tell what to count on.
+
+### 4. LLM guide files appear in the user-facing nav
+`llm-guide.md` and `llm-reference.md` are machine-targeted context files. They have no Jekyll frontmatter, so they appear in the sidebar as plain items alongside user-facing guides. Regular developers clicking them get a terse reference not intended for them.
+
+### 5. Getting started is buried inside Guides
+`getting-started.md` has `parent: Guides` and `nav_order: 1`, making it a child page under the Guides hub. For a framework's documentation, getting started should be a direct top-level item.
+
+---
+
+## Out of Scope
+
+- Changes to individual guide/reference pages (separate audit pass)
+- `blog-api-example.md` — it is a child of Examples and correctly linked from `examples.md`; no change needed
+- Any content changes to LLM guide files — only their nav visibility changes
+
+---
+
+## Changes
+
+### Change 1: Homepage opening and "Why Shaperail"
+
+**File:** `docs/index.md`
+
+**New opening line (replaces current H1 subtext):**
+> Define your API as YAML resources. Shaperail generates the Rust backend — routes, database schema, validation, auth, migrations, and OpenAPI — from that one file.
+
+**New "Why Shaperail" section — pain-first structure:**
+
+Open with the problem statement: a single REST resource in plain Rust spans handler files, database models, migration SQL, validation logic, auth middleware, and OpenAPI annotations — typically 300–500 lines across 5+ files. Add another resource, repeat the work. Shaperail replaces that with one ~40-line YAML file. The framework reads that file and generates the Rust, the SQL, and the spec deterministically.
+
+Follow with the existing principles table (One source of truth, Explicit over implicit, etc.) as supporting detail — it stays, but it supports the story rather than leading it.
+
+Move "AI-native" language to a brief note at the end of the section: the docs, codegen, and runtime are kept in sync specifically so that LLMs can generate valid Shaperail resources and commands with minimal mistakes. This is what "AI-native" means in practice.
+
+**"When to use Shaperail" table** — keep as-is, it is already well-written.
+
+**"What you author" table** — remove the awkward caveat language in the Role column. Replace "One workable convention for controller modules; current apps still require manual controller registration" with "Business logic before/after DB writes — see [Controllers](/controllers/)" and trust the Controllers guide to explain registration.
+
+---
+
+### Change 2: Feature tier split
+
+**File:** `docs/index.md` — replace the current "Features at a glance" section
+
+Replace the single bullet list with three named tiers.
+
+**Tier 1 — Production-ready today**
+Everything in this tier works out of the box from a resource YAML file with no manual wiring:
+- REST API: list, get, create, update, delete, bulk operations; cursor and offset pagination; filters, sort, full-text search; field selection; relation loading (`?include=`)
+- JWT authentication; role-based and owner-based access control per endpoint
+- Redis caching with TTL, auto-invalidation on writes, configurable `invalidate_on`
+- File storage: local, S3, GCS, Azure; upload validation, signed URLs, image processing
+- Multi-tenancy: row-level isolation via `tenant_key`; per-tenant cache and rate-limit keys; `super_admin` bypass
+- Observability: structured JSON logs, request_id propagation, Prometheus metrics, health endpoints, OpenTelemetry trace export
+- Database migrations: initial create-table SQL generated from schema; sqlx compile-time verified
+- OpenAPI 3.1 spec generation; TypeScript SDK generation
+- WASM plugins: controller hooks in TypeScript, Python, Rust, or any WASM-targeting language; sandboxed, fuel-limited, crash-isolated
+
+**Tier 2 — Available, requires manual wiring**
+The runtime primitives exist and are documented. Connecting them requires code in your app's `main.rs` or config. The relevant guide explains exactly what to wire and how:
+- Background jobs — queue and worker primitives; worker registration and handler mapping are manual (see [Background jobs](/background-jobs/))
+- Events and webhooks — event emission from write handlers works; subscriber execution and inbound route registration are manual (see [Events and webhooks](/events-and-webhooks/))
+- WebSockets — session and channel primitives work; route registration is manual (see [WebSockets](/websockets/))
+- API key auth — runtime primitive exists; wiring to endpoints is manual (see [Auth and ownership](/auth-and-ownership/))
+- Rate limiting — primitive exists; wiring is manual (see [Auth and ownership](/auth-and-ownership/))
+- GraphQL — enable with `protocols: [rest, graphql]`; generates list/get queries and create/update/delete mutations; list queries currently support `limit`/`offset` only (see [GraphQL](/graphql/))
+- gRPC — enable with `protocols: [rest, grpc]`; supports list, stream, get, create, delete; `Update` RPC is not implemented (see [gRPC](/grpc/))
+
+**Tier 3 — In progress**
+These items have partial scaffolding or runtime stubs but are not complete:
+- gRPC Update RPC
+- WebSocket auto-routing from channel YAML files
+- Events subscriber auto-execution
+- Workspace service registry and saga orchestration
+- Background job worker auto-registration
+
+---
+
+### Change 3: Nav cleanup
+
+**Files:** `docs/llm-guide.md`, `docs/llm-reference.md`, `docs/getting-started.md`
+
+**`llm-guide.md` and `llm-reference.md`:**
+Add Jekyll frontmatter with `nav_exclude: true`. The files remain accessible by direct URL. Add a brief note at the bottom of the "Why Shaperail" section on `docs/index.md` that links to them: "Working with an LLM? Load [llm-guide.md](/llm-guide/) as context — it is the sole file an AI assistant needs to generate valid Shaperail resources." They should not be in the sidebar because they are not written for human navigation.
+
+```yaml
+---
+title: Shaperail LLM Guide
+nav_exclude: true
+---
+```
+
+```yaml
+---
+title: Shaperail Quick Reference
+nav_exclude: true
+---
+```
+
+**`getting-started.md`:**
+Remove `parent: Guides`. Set `nav_order: 2` so it appears as a top-level nav item directly after the homepage. Renumber the Guides hub to `nav_order: 3`, Reference to `nav_order: 4`, Examples to `nav_order: 5`.
+
+```yaml
+---
+title: Getting started
+nav_order: 2
+---
+```
+
+---
+
+## Files Changed
+
+| File | Type of change |
+|------|----------------|
+| `docs/index.md` | Rewrite opening, Why section, feature tiers, What you author table |
+| `docs/getting-started.md` | Remove `parent: Guides`, set `nav_order: 2` |
+| `docs/guides.md` | `nav_order: 2` → `3` |
+| `docs/reference.md` | `nav_order: 3` → `4` |
+| `docs/examples.md` | `nav_order: 4` → `5` |
+| `docs/llm-guide.md` | Add `nav_exclude: true` frontmatter |
+| `docs/llm-reference.md` | Add `nav_exclude: true` frontmatter |
+
+---
+
+## Success Criteria
+
+- A developer landing on the homepage can state in one sentence what Shaperail does and what problem it solves within 10 seconds of reading
+- The features section makes it unambiguous what requires manual work vs. what works from YAML alone
+- `llm-guide.md` and `llm-reference.md` no longer appear in the sidebar
+- Getting started is a direct top-level nav item


### PR DESCRIPTION
## Summary

- **Homepage rewrite** — new tagline explains the product in one sentence ("Define your API as YAML resources. Shaperail generates the Rust backend…"); Why Shaperail section now leads with the pain (300–500 lines per resource in plain Rust) before the principles table; removed the duplicate Documentation map section
- **Feature tier split** — replaced the flat 17-bullet Features at a glance list with three named tiers: Production-ready today (works from YAML alone), Available — requires manual wiring (primitives exist, guides linked), In progress (incomplete); accuracy-reviewed against each guide page
- **Nav cleanup** — `getting-started.md` promoted to standalone top-level nav item (removed `parent: Guides`); `llm-guide.md` and `llm-reference.md` hidden from sidebar with `nav_exclude: true` (machine-targeted files, still accessible by direct URL); hub pages renumbered (Guides→3, Reference→4, Examples→5)

## Test Plan

- [ ] Verify sidebar shows: Home → Getting started → Guides → Reference → Examples (no LLM files)
- [ ] Verify `llm-guide.md` and `llm-reference.md` are accessible at their direct URLs
- [ ] Verify homepage tagline, Why Shaperail pain paragraph, and three-tier feature section render correctly
- [ ] Confirm Documentation map section is gone from homepage
- [ ] Confirm "LLM Guide" link in Why Shaperail blockquote works

🤖 Generated with [Claude Code](https://claude.com/claude-code)