### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Shaperail will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-20
+
+### Changed
+
+- Add shaperail llm-context command for project-aware LLM context dumps
+- Add llm-guide.md and llm-reference.md — machine-readable context files for AI assistants
+- Add JSON Schema for resource YAML (docs/schema/resource.schema.json)
+- Add runnable incident platform example
+- LLM anti-pattern audit: remove alternative syntax from examples, fix canonical format values
+- Doc overhaul: pain-first homepage, three-tier feature list, nav cleanup
+
+
 ## [0.7.0] - 2026-03-17
 
 ### Added
@@ -144,3 +156,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/shaperail/shaperail/releases/tag/v0.2.0
 [0.7.0]: https://github.com/shaperail/shaperail/releases/tag/v0.7.0
 [0.6.0]: https://github.com/shaperail/shaperail/releases/tag/v0.6.0
+[0.8.0]: https://github.com/shaperail/shaperail/releases/tag/v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-codegen"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "indexmap",
  "insta",
@@ -4735,7 +4735,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-runtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "actix-multipart",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shaperail-core", "shaperail-codegen", "shaperail-runtime", "shaperai
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ description: Deterministic Rust backend generation from explicit YAML resources.
 url: https://shaperail.io
 baseurl: ""
 repository: shaperail/shaperail
-release_version: 0.7.0
+release_version: 0.8.0
 markdown: kramdown
 permalink: pretty
 remote_theme: just-the-docs/just-the-docs@v0.12.0

--- a/shaperail-cli/Cargo.toml
+++ b/shaperail-cli/Cargo.toml
@@ -15,9 +15,9 @@ name = "shaperail"
 path = "src/main.rs"
 
 [dependencies]
-shaperail-codegen = { version = "0.7.0", path = "../shaperail-codegen" }
-shaperail-core = { version = "0.7.0", path = "../shaperail-core" }
-shaperail-runtime = { version = "0.7.0", path = "../shaperail-runtime" }
+shaperail-codegen = { version = "0.8.0", path = "../shaperail-codegen" }
+shaperail-core = { version = "0.8.0", path = "../shaperail-core" }
+shaperail-runtime = { version = "0.8.0", path = "../shaperail-runtime" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/shaperail-codegen/Cargo.toml
+++ b/shaperail-codegen/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-shaperail-core = { version = "0.7.0", path = "../shaperail-core" }
+shaperail-core = { version = "0.8.0", path = "../shaperail-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/shaperail-runtime/Cargo.toml
+++ b/shaperail-runtime/Cargo.toml
@@ -19,7 +19,7 @@ multi-db = ["dep:mongodb"]
 observability-otlp = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry_sdk"]
 
 [dependencies]
-shaperail-core = { version = "0.7.0", path = "../shaperail-core" }
+shaperail-core = { version = "0.8.0", path = "../shaperail-core" }
 actix-web = { workspace = true }
 actix-ws = { workspace = true }
 actix-multipart = { workspace = true }


### PR DESCRIPTION
## Release v0.8.0

Prepared automatically from `main`.

### Checklist

- [ ] Review version bump and changelog
- [ ] Confirm CI is green
- [ ] Merge this PR before running the `Release` workflow

### Changelog summary

- Add `shaperail llm-context` command for project-aware LLM context dumps
- Add `llm-guide.md` and `llm-reference.md` — machine-readable context files for AI assistants
- Add JSON Schema for resource YAML (`docs/schema/resource.schema.json`)
- Add runnable incident platform example
- LLM anti-pattern audit: remove alternative syntax from examples, fix canonical format values
- Doc overhaul: pain-first homepage, three-tier feature list, nav cleanup