### PR TITLE
chore(release): add CHANGELOG link refs for 0.9.0 and 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,3 +198,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.7.0]: https://github.com/shaperail/shaperail/releases/tag/v0.7.0
 [0.6.0]: https://github.com/shaperail/shaperail/releases/tag/v0.6.0
 [0.8.0]: https://github.com/shaperail/shaperail/releases/tag/v0.8.0
+[0.9.0]: https://github.com/shaperail/shaperail/releases/tag/v0.9.0
+[0.10.0]: https://github.com/shaperail/shaperail/releases/tag/v0.10.0


### PR DESCRIPTION
## Why

Auto-release's `assert-release-version.sh` checks that CHANGELOG.md contains both:

1. A `## [VERSION]` heading
2. A markdown link reference: `[VERSION]: https://github.com/shaperail/shaperail/releases/tag/vVERSION`

PR #69 added the `## [0.10.0]` heading but missed the link reference. The script exits 1 silently on the `grep -Fq` (no error message echoed), which is what made the auto-release fail at the `Validate and test` step without a visible reason.

## Fix

Add the missing link refs at the end of CHANGELOG.md:

```diff
 [0.8.0]: https://github.com/shaperail/shaperail/releases/tag/v0.8.0
+[0.9.0]: https://github.com/shaperail/shaperail/releases/tag/v0.9.0
+[0.10.0]: https://github.com/shaperail/shaperail/releases/tag/v0.10.0
```

Includes 0.9.0 even though that version was never tagged — the heading already exists in CHANGELOG so the dangling link reference is just metadata consistency, no actual release.

## Verified

```
bash .github/scripts/assert-release-version.sh 0.10.0
exit=0
```

## After merge

`auto-release.yml` should re-fire on push to main, the assertion now passes, and the rest of the pipeline (build → publish → tag → GitHub Release) runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)