### PR TITLE
docs + release-metadata: complete v0.11.0 (follow-up to #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,3 +235,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.9.0]: https://github.com/shaperail/shaperail/releases/tag/v0.9.0
 [0.10.0]: https://github.com/shaperail/shaperail/releases/tag/v0.10.0
 [0.10.1]: https://github.com/shaperail/shaperail/releases/tag/v0.10.1
+[0.11.0]: https://github.com/shaperail/shaperail/releases/tag/v0.11.0

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ description: Deterministic Rust backend generation from explicit YAML resources.
 url: https://shaperail.io
 baseurl: ""
 repository: shaperail/shaperail
-release_version: 0.10.1
+release_version: 0.11.0
 markdown: kramdown
 permalink: pretty
 remote_theme: just-the-docs/just-the-docs@v0.12.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,12 +26,13 @@ project: my-api
 port: 8080
 workers: 4
 
-database:
-  type: postgresql
-  host: ${DB_HOST:localhost}
-  port: 5432
-  name: my_api_db
-  pool_size: 20
+databases:
+  default:
+    engine: postgres
+    # `.env` sets DATABASE_URL, which overrides the fallback below.
+    # Edit `.env` (not this file) for local connection strings.
+    url: ${DATABASE_URL:postgresql://localhost/my_api_db}
+    pool_size: 20
 
 cache:
   type: redis
@@ -145,21 +146,46 @@ grpc:
 | `port` | integer | `50051` | Port for the gRPC server. Separate from the HTTP `port`. |
 | `reflection` | boolean | `true` | Enable gRPC server reflection for tools like `grpcurl`. |
 
-### `database`
+### `databases`
 
-Optional. Single-database (legacy) mode. When omitted, no database pool is
-created. **Ignored when `databases` is set** — use `databases` for
-multi-database or to name your primary connection explicitly.
+> **Migrating from v0.10:** The legacy singular `database:` block was removed in
+> v0.11. Configs containing it now fail to parse with `unknown field 'database'`.
+> Replace the block with `databases.default:` as shown below.
 
-| Field | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| `type` | string | yes | -- | Database engine. Use `postgresql`. |
-| `host` | string | no | `localhost` | Database server hostname. |
-| `port` | integer | no | `5432` | Database server port. |
-| `name` | string | yes | -- | Database name. |
-| `pool_size` | integer | no | `20` | Maximum connections in the sqlx pool. |
+Optional. Named database connections. Every new project scaffolded by
+`shaperail init` uses this form. When omitted, no database pool is created.
 
-### `databases` (multi-database)
+The recommended form (also what `shaperail init` now generates):
+
+```yaml
+databases:
+  default:
+    engine: postgres
+    # `.env` sets DATABASE_URL, which overrides the fallback below.
+    # Edit `.env` (not this file) for local connection strings.
+    url: ${DATABASE_URL:postgresql://localhost/<project>}
+    pool_size: 20
+```
+
+You must include a connection named **`default`**; migrations run against the
+`default` connection. Use `${VAR}` or `${VAR:default}` in URLs for environment
+variable interpolation.
+
+For multi-database setups, add additional named connections:
+
+```yaml
+databases:
+  default:
+    engine: postgres
+    url: ${DATABASE_URL}
+    pool_size: 20
+  analytics:
+    engine: postgres
+    url: postgres://user:pass@analytics-db.example.com/analytics
+    pool_size: 10
+```
+
+### `databases` — connection options
 
 Optional. Named database connections for multi-database projects. When set,
 the server uses an ORM-backed store and routes each resource to the connection
@@ -326,10 +352,11 @@ Use `${VAR}` to inject an environment variable at parse time. Use
 
 ```yaml
 project: ${APP_NAME:my-app}
-database:
-  type: postgresql
-  host: ${DB_HOST:localhost}
-  name: ${DB_NAME}
+databases:
+  default:
+    engine: postgres
+    url: ${DATABASE_URL:postgresql://localhost/${DB_NAME}}
+    pool_size: 20
 ```
 
 Rules:
@@ -356,7 +383,7 @@ Shaperail rejects invalid configuration at startup with a clear error message.
 
 - **`project` is required.** Omitting it produces a "missing field" error.
 - **Unknown fields are rejected.** Every section uses `deny_unknown_fields`. A
-  typo like `databse:` instead of `database:` produces an "unknown field" error
+  typo like `databse:` instead of `databases:` produces an "unknown field" error
   listing the valid alternatives.
 - **Type mismatches fail.** Setting `port: "not-a-number"` or `workers: []`
   produces a deserialization error.

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -15,9 +15,17 @@ For background work that should not block the response, use
 
 ---
 
+> **Note:** `controller: { before, after }` is only valid on conventional CRUD
+> endpoints (`list` / `get` / `create` / `update` / `delete` / `bulk_create` /
+> `bulk_delete`). Declaring `controller:` on a custom endpoint (one that uses
+> `handler:`) now fails `shaperail check` with a clear error. For shared logic
+> on custom handlers, use the `Subject` API from `shaperail_runtime::auth`
+> directly inside your handler — see [Multi-tenancy]({{ '/multi-tenancy/' | relative_url }})
+> for the pattern.
+
 ## Declaring controllers
 
-Add a `controller` field to any endpoint in your resource YAML:
+Add a `controller` field to any CRUD endpoint in your resource YAML:
 
 ```yaml
 resource: users
@@ -153,6 +161,8 @@ The `Context` struct is the single type passed to all controller functions:
 | `headers` | `HashMap<String, String>` | before + after | Read-only copy of the request headers. |
 | `response_headers` | `Vec<(String, String)>` | before + after | Push `(name, value)` pairs to add extra response headers. |
 | `tenant_id` | `Option<String>` | before + after | The tenant ID from the JWT claim, when the resource has `tenant_key` set. Use for tenant-specific business logic. |
+| `session` | `serde_json::Map<String, Value>` | before + after | Cross-phase scratch space. Anything written in `before:` is visible in `after:`. Never persisted, never serialized to the client. |
+| `response_extras` | `serde_json::Map<String, Value>` | before + after | Keys merged into the response's `data:` envelope after the after-hook returns. Never persisted. Use for one-time values like minted secrets that must reach the client exactly once. |
 
 ---
 
@@ -182,9 +192,58 @@ Key behaviors:
   with the corresponding error response. For before-controllers, the DB
   operation is skipped entirely.
 
+### Preserved-Context lifecycle
+
+The **same `Context` struct instance** is used for both the before- and
+after-phase of a single request. This means:
+
+- `ctx.input` is not reset between phases — modifications from the before-phase
+  are still visible in the after-phase.
+- State written to `ctx.session` in `before:` is readable in `after:`.
+- Keys placed in `ctx.response_extras` in either phase are merged into the
+  outgoing response's `data:` envelope before the HTTP response is sent. They
+  are never written to the database.
+
+Use `ctx.session` to communicate between the two phases without touching
+`ctx.input` or `ctx.data`.
+
 ---
 
 ## Common patterns
+
+### One-time secret on create
+
+Use `ctx.session` to pass a plaintext value from the before-phase to the
+after-phase without exposing it to the database or to intermediate log output.
+The after-phase then places it in `ctx.response_extras` so it appears in the
+response exactly once:
+
+```rust
+// resources/agents.controller.rs
+use shaperail_runtime::handlers::controller::{Context, ControllerResult};
+
+/// Mints a 32-byte secret on agent create:
+///  - before: stores the hash on the row, stashes plaintext in session
+///  - after:  moves plaintext from session into response_extras
+pub async fn mint_mcp_secret(ctx: &mut Context) -> ControllerResult {
+    if ctx.data.is_none() {
+        // before-phase: write hash to DB, stash plaintext for the after-hook
+        let plaintext = generate_random_secret_32_bytes();
+        let hash = hash_secret(&plaintext);
+        ctx.input.insert("mcp_secret_hash".into(), serde_json::json!(hash));
+        ctx.session.insert("plaintext".into(), serde_json::json!(plaintext));
+    } else {
+        // after-phase: hand the plaintext to the response
+        if let Some(plaintext) = ctx.session.remove("plaintext") {
+            ctx.response_extras.insert("mcp_secret".into(), plaintext);
+        }
+    }
+    Ok(())
+}
+```
+
+The response `data:` envelope will contain `"mcp_secret": "<value>"` for this
+one request. Subsequent reads of the agent record will not include it.
 
 ### Auto-fill `created_by` from token
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,12 +120,11 @@ project: my-app
 port: ${SHAPERAIL_PORT:3000}
 workers: auto
 
-database:
-  type: postgresql
-  host: ${DB_HOST}
-  port: ${DB_PORT:5432}
-  name: ${DB_NAME}
-  pool_size: ${DB_POOL_SIZE:20}
+databases:
+  default:
+    engine: postgres
+    url: ${DATABASE_URL}
+    pool_size: ${DB_POOL_SIZE:20}
 
 cache:
   type: redis
@@ -169,12 +168,11 @@ migrations, monitoring, and admin connections.
 
 ```yaml
 # For a 4-replica deployment with Postgres max_connections=100
-database:
-  type: postgresql
-  host: ${DB_HOST}
-  port: 5432
-  name: my_app
-  pool_size: 20  # 4 replicas x 20 = 80 connections, leaving 20 for admin
+databases:
+  default:
+    engine: postgres
+    url: ${DATABASE_URL}
+    pool_size: 20  # 4 replicas x 20 = 80 connections, leaving 20 for admin
 ```
 
 For multi-database setups, configure each connection independently:

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -93,7 +93,7 @@ For custom endpoints, provide `method:` and `path:` explicitly.
 | sort        | ✓    |        |     |        |        |        |
 | pagination  | ✓    |        |     |        |        |        |
 | cache       | ✓    | ✓      | ✓   |        |        | ✓      |
-| controller  | ✓    | ✓      | ✓   | ✓      | ✓      | ✓      |
+| controller  | ✓    | ✓      | ✓   | ✓      | ✓      |        |
 | events      |      | ✓      |     | ✓      | ✓      |        |
 | jobs        |      | ✓      |     | ✓      | ✓      |        |
 | soft_delete |      |        |     |        | ✓      |        |
@@ -106,7 +106,7 @@ Key details:
 - `auth`: list of role names from your auth config, or `owner` (matches record creator)
 - `pagination`: `cursor` (default) or `offset` — no other values
 - `cache`: `{ ttl: <seconds> }`
-- `controller`: `{ before: <fn_name> }` and/or `{ after: <fn_name> }` — fn in `resources/<name>.controller.rs`
+- `controller`: `{ before: <fn_name> }` and/or `{ after: <fn_name> }` — fn in `resources/<name>.controller.rs`. Only valid on CRUD endpoints (`list`/`get`/`create`/`update`/`delete`/`bulk_create`/`bulk_delete`). Declaring `controller:` on a custom endpoint (`handler:`) is a validation error.
 - `input`: list of field names from `schema:` — not field definitions
 - `sort`: list of field names that clients can sort by
 - `filters`: list of field names that clients can filter on
@@ -116,7 +116,7 @@ Key details:
 
 ## 5. Controller Pattern
 
-Reference a controller in an endpoint:
+Reference a controller in a CRUD endpoint:
 
 ```yaml
 endpoints:
@@ -130,33 +130,44 @@ The function lives in `resources/<resource_name>.controller.rs` (same directory 
 
 ```rust
 // resources/users.controller.rs
-use shaperail_runtime::ControllerContext;
+use shaperail_runtime::handlers::controller::{Context, ControllerResult};
+use shaperail_core::ShaperailError;
 
-// before hook — return Err("message") to abort with HTTP 422
-pub async fn validate_org(ctx: &mut ControllerContext) -> Result<(), String> {
-    let org_id = ctx.input["org_id"].as_str().ok_or("org_id required")?;
+// before hook — return Err(...) to abort with the corresponding HTTP error
+pub async fn validate_org(ctx: &mut Context) -> ControllerResult {
+    let org_id = ctx.input.get("org_id").and_then(|v| v.as_str()).ok_or(ShaperailError::Unauthorized)?;
     if org_id.is_empty() {
-        return Err("org_id must not be empty".into());
+        return Err(ShaperailError::Unauthorized);
     }
     Ok(())
 }
 
-// after hook — ctx.output has the created/updated record
-pub async fn notify_team(ctx: &ControllerContext) -> Result<(), String> {
-    let _id = &ctx.output["id"];
-    // fire side effects here
+// after hook — ctx.data has the created/updated record
+pub async fn notify_team(ctx: &mut Context) -> ControllerResult {
+    if let Some(data) = &ctx.data {
+        let _id = &data["id"];
+        // fire side effects here
+    }
     Ok(())
 }
 ```
 
-`ControllerContext` fields:
-| Field       | Type                  | Available in   | Description                                   |
-|-------------|-----------------------|----------------|-----------------------------------------------|
-| input       | serde_json::Value     | before + after | Request body (before) / saved record (after)  |
-| output      | serde_json::Value     | after only     | The record returned by the operation          |
-| user_id     | Option<uuid::Uuid>    | before + after | Authenticated user, None if no auth           |
-| tenant_id   | Option<uuid::Uuid>    | before + after | Current tenant, None if no multi-tenancy      |
-| resource    | &str                  | before + after | Resource name (e.g., "users")                 |
+`Context` fields:
+| Field            | Type                              | Available in   | Description                                                                  |
+|------------------|-----------------------------------|----------------|------------------------------------------------------------------------------|
+| `input`          | `serde_json::Map<String, Value>`  | before + after | Mutable request input. The same instance is shared across both phases.       |
+| `data`           | `Option<serde_json::Value>`       | after only     | The database result. `None` in before-controllers, `Some(...)` in after.     |
+| `session`        | `serde_json::Map<String, Value>`  | before + after | Cross-phase scratch space. Write in `before:`, read in `after:`. Never persisted. |
+| `response_extras`| `serde_json::Map<String, Value>`  | before + after | Merged into the response `data:` envelope. Never persisted.                  |
+| `user`           | `Option<AuthenticatedUser>`       | before + after | Authenticated user (`id`, `role`, `tenant_id`). `None` if no auth.           |
+| `tenant_id`      | `Option<String>`                  | before + after | Current tenant, when resource has `tenant_key`. `None` otherwise.            |
+| `pool`           | `sqlx::PgPool`                    | before + after | DB connection pool for custom queries.                                       |
+| `response_headers`| `Vec<(String, String)>`          | before + after | Push `(name, value)` pairs to add response headers.                          |
+
+The same `Context` struct instance is used for both phases. State written to
+`ctx.session` in the before-phase is visible in the after-phase. Use
+`ctx.response_extras` to send one-time values (like minted secrets) that must
+appear in the response but must never be stored.
 
 ---
 

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -204,3 +204,50 @@ schema:
   records separately. The framework only filters by the declared key.
 - **Auto-fill tenant_id in JWT** -- Your auth service must include `tenant_id`
   in the JWT claims. Shaperail reads it but does not generate it.
+
+## Custom handlers — opt-in tenant scoping
+
+Custom endpoints (those declaring `handler:` instead of one of the conventional
+CRUD actions) do **not** get automatic tenant isolation — the framework cannot
+infer your data flow. Use the `Subject` API in `shaperail_runtime::auth` to
+extract the role/tenant and apply scoping explicitly:
+
+~~~rust
+use shaperail_runtime::auth::Subject;
+use sqlx::{Postgres, QueryBuilder};
+
+pub async fn regenerate_secret(
+    req: actix_web::HttpRequest,
+    /* state, path params, etc. */
+) -> actix_web::HttpResponse {
+    let subject = match Subject::from_request(&req) {
+        Ok(s) => s,
+        Err(_) => return actix_web::HttpResponse::Unauthorized().finish(),
+    };
+
+    let mut q = QueryBuilder::<Postgres>::new("UPDATE agents SET mcp_secret_hash = ");
+    q.push_bind(/* new_hash */ "");
+    q.push(" WHERE id = ");
+    q.push_bind(/* agent_id */ uuid::Uuid::nil());
+
+    // No-op for super_admin; appends `AND org_id = $N` for everyone else.
+    if subject.scope_to_tenant(&mut q, "org_id").is_err() {
+        return actix_web::HttpResponse::Unauthorized().finish();
+    }
+
+    // execute q ...
+    actix_web::HttpResponse::Ok().finish()
+}
+~~~
+
+`Subject` exposes:
+
+| Method | Description |
+| --- | --- |
+| `is_super_admin()` | Returns `true` for the global `super_admin` role, which is exempt from tenant filtering. |
+| `tenant_filter()` | `Ok(None)` for super_admin; `Ok(Some(t))` for a normal user with a `tenant_id` claim; `Err(Unauthorized)` for a normal user with no `tenant_id` claim. |
+| `assert_tenant_match(record_tenant_id)` | For read-then-validate flows — returns an error if the record's tenant does not match the authenticated user's tenant. |
+| `scope_to_tenant(query_builder, column)` | Appends `AND <column> = $N` to a sqlx `QueryBuilder<Postgres>`; no-op for super_admin. |
+
+CRUD endpoints continue to apply this scoping automatically via `tenant_key`.
+You only need `Subject` when you write custom handlers.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,11 +39,11 @@ The `pool_size` setting in `shaperail.config.yaml` controls the maximum number
 of connections in the sqlx pool:
 
 ```yaml
-database:
-  type: postgresql
-  host: localhost
-  name: my_db
-  pool_size: 20
+databases:
+  default:
+    engine: postgres
+    url: ${DATABASE_URL:postgresql://localhost/my_db}
+    pool_size: 20
 ```
 
 Guidelines for sizing:

--- a/docs/security.md
+++ b/docs/security.md
@@ -140,6 +140,38 @@ To rotate the JWT secret without downtime:
 For zero-downtime rotation, implement a controller that accepts tokens signed
 with either the old or new secret during the transition window.
 
+### JWT Claims
+
+Shaperail mints HS256 JWTs with this claim shape (`shaperail_runtime::auth::Claims`,
+re-exported from the auth module):
+
+| Claim | Required for | Notes |
+| --- | --- | --- |
+| `sub` | always | User ID, typically a UUID. |
+| `role` | always | Must match a role in any endpoint's `auth:` list, or be `super_admin` for unrestricted access. |
+| `iat` / `exp` | always | Unix seconds. |
+| `token_type` | always | `"access"` for protected requests; `"refresh"` is only valid against the refresh endpoint. |
+| `tenant_id` | non-`super_admin` accessing tenant-scoped resources | Missing/null → 401. |
+
+**Minting a token for tests:**
+
+```rust
+use shaperail_runtime::auth::JwtConfig;
+
+let config = JwtConfig::new("test-secret-at-least-32-bytes-long!", 3600, 86400);
+let token = config
+    .encode_access_with_tenant("user-uuid", "admin", Some("org-uuid"))
+    .unwrap();
+```
+
+**Diagnosing 401s:** the runtime emits `tracing::warn!` lines when JWTs are
+rejected. Set `RUST_LOG=shaperail_runtime::auth=warn` to surface them. Two
+common messages:
+
+- `JWT rejected: decode failed` — signature mismatch, expired, or malformed.
+- `JWT rejected: token_type must be "access"` — typically a refresh token sent
+  against a protected endpoint.
+
 ### Refresh token handling
 
 - The JWT payload includes a `token_type` field (`access` or `refresh`). Only

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -883,6 +883,118 @@ ON CONFLICT DO NOTHING;
 
 ---
 
+## Integration tests with `test_support`
+
+`shaperail-runtime` ships a `test-support` cargo feature that provides
+`TestServer`, `spawn_with_listener`, and `ensure_migrations_run`. These let you
+spin up the full Actix server in-process on an ephemeral port and make real HTTP
+requests against it — without mocking any layer.
+
+> **Note:** Future versions of `shaperail init` will generate the lib/bin split
+> described here automatically. Until then, the steps below are a one-time edit
+> per project.
+
+### Step 1 — split `src/main.rs` into a library + binary
+
+Add an explicit `[lib]` target to `Cargo.toml` alongside the binary, and pull
+in the dev-dependencies:
+
+```toml
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "my-app"
+path = "src/main.rs"
+
+[dev-dependencies]
+shaperail-runtime = { workspace = true, features = ["test-support"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+```
+
+### Step 2 — expose `build_server` from `src/lib.rs`
+
+Move the existing bootstrap logic (config, pool, registry, route registration)
+into a public function that accepts a `TcpListener` and returns the unawaited
+`actix_web::dev::Server`:
+
+```rust
+// src/lib.rs
+use std::net::TcpListener;
+use actix_web::dev::Server;
+
+pub fn build_server(listener: TcpListener) -> std::io::Result<Server> {
+    // ... config, pool setup, resource registry, middleware ...
+    let server = actix_web::HttpServer::new(move || {
+        // ... App::new().route(...) ...
+    })
+    .listen(listener)?
+    .run();
+    Ok(server)
+}
+```
+
+### Step 3 — collapse `src/main.rs` to a thin caller
+
+```rust
+// src/main.rs
+use std::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3000);
+    let listener = TcpListener::bind(("0.0.0.0", port))?;
+    my_app::build_server(listener)?.await
+}
+```
+
+### Step 4 — write `tests/integration.rs`
+
+```rust
+// tests/integration.rs
+use std::net::TcpListener;
+
+#[tokio::test]
+async fn health_responds_200() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let server = shaperail_runtime::test_support::spawn_with_listener(
+        listener,
+        my_app::build_server,
+    )
+    .await
+    .unwrap();
+
+    let resp = reqwest::get(server.url("/health")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+```
+
+`spawn_with_listener` binds to port 0 (OS assigns an ephemeral port) and
+returns a `TestServer` whose `Drop` aborts the spawned task. Tests that start
+multiple server instances will each get a unique port with no conflicts.
+
+### Running migrations once per test process
+
+For database-backed integration tests, call `ensure_migrations_run` before your
+first query. The helper is gated on a `tokio::sync::OnceCell`, so parallel
+tests share a single migration sweep instead of contending on the Postgres
+advisory lock:
+
+```rust
+use shaperail_runtime::test_support::ensure_migrations_run;
+
+#[tokio::test]
+async fn test_create_user(pool: sqlx::PgPool) {
+    ensure_migrations_run(&pool).await.expect("migrations");
+    // ... test body ...
+}
+```
+
+---
+
 ## CI/CD testing patterns
 
 ### Docker-based CI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,8 +124,11 @@ Too many concurrent requests for the pool size. Increase the pool in
 `shaperail.config.yaml`:
 
 ```yaml
-database:
-  max_connections: 20   # default is 10
+databases:
+  default:
+    engine: postgres
+    url: ${DATABASE_URL}
+    pool_size: 20   # default is 10
 ```
 
 Or reduce the number of Actix workers so each worker gets enough connections.


### PR DESCRIPTION
## Summary

Follow-up to #73 (which shipped v0.11.0). The public-facing `docs/` site was not part of #73 — only `agent_docs/` (internal). This PR mirrors those updates into the user-facing site so the GitHub Pages docs at shaperail.io reflect the v0.11.0 API.

Single squash-mergable commit, no source changes, no version bump.

## Files updated

| File | Change |
|---|---|
| `docs/configuration.md` | Replaced both `database:` (singular) YAML examples with `databases.default:`. Added v0.11 migration callout. |
| `docs/controllers.md` | Documented `Context.session`, `Context.response_extras`, the preserved-Context lifecycle, and rejection of `controller:` on custom endpoints. Added the one-time-secret recipe. |
| `docs/multi-tenancy.md` | New "Custom handlers — opt-in tenant scoping" section covering `Subject` API and `QueryBuilder` example. |
| `docs/testing.md` | New section on `shaperail_runtime::test_support` and the manual `lib.rs`/`main.rs` split required to use it. |
| `docs/security.md` | Added JWT Claims claim-shape table, test-token recipe, and `tracing` diagnostics on rejection. |
| `docs/llm-guide.md` | Removed `controller:` column for custom endpoints in the controller table. Replaced `ctx.output` with `ctx.data`. Expanded context field table to include `session`, `response_extras`, `pool`, `response_headers`. |
| `docs/deployment.md`, `docs/performance.md`, `docs/troubleshooting.md` | Converted remaining `database:` YAML examples to `databases.default:`. |

## Why this is a separate PR

PR #73 merged before I had a chance to add the docs commit. The auto-release workflow has already shipped v0.11.0, so the docs site rebuild on this merge will catch up — no version bump needed.

## Verification

- `grep -rn "^database:" docs/*.md` (excluding `superpowers/`) returns only one false-positive prose hit in `security.md:27` ("...reaching the database:" — sentence-final colon, not a YAML key).
- `grep -rn "ctx\.output\b" docs/*.md` returns zero hits.
- All new sections render as valid Markdown.

## Test plan

- [x] Markdown renders cleanly (no broken code fences).
- [x] No `database:` YAML config blocks remain in user-facing pages.
- [x] No source-code changes; CI should pass on doc-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)