### PR TITLE
v0.11.0 release readiness: audit-ignore + 5 follow-up fixes (A–E)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,6 +2,19 @@
 # `sqlx` 0.8.6 still lists the MySQL backend in Cargo.lock even when the
 # workspace only enables PostgreSQL. The vulnerable `rsa` chain is therefore
 # present in audit metadata but not in compiled artifacts or runtime code.
-ignore = ["RUSTSEC-2023-0071"]
+#
+# RUSTSEC-2026-0118 / RUSTSEC-2026-0119 — hickory-proto 0.25.2 (CPU exhaustion
+# during message encoding; NSEC3 closest-encloser proof unbounded loop). Both
+# are transitive deps of `mongodb 3.6.0` (the latest mongodb release on
+# crates.io), which still pins `hickory-proto = "^0.25"`. Cannot upgrade
+# until mongodb publishes a release that bumps to 0.26+. Both advisories
+# affect DNS resolution paths only; the SQL- and Redis-backed default
+# configurations of Shaperail do not exercise hickory at all.
+# Track upstream: https://github.com/mongodb/mongo-rust-driver
+ignore = [
+    "RUSTSEC-2023-0071",
+    "RUSTSEC-2026-0118",
+    "RUSTSEC-2026-0119",
+]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"


### PR DESCRIPTION
## What

PR #75 has grown beyond the original audit-ignore. It now bundles **all** the work needed to ship a clean v0.11.0 to crates.io:

1. **Audit-ignore** — unblocks the auto-release after two new RUSTSEC advisories landed for `hickory-proto 0.25.2` (transitive via `mongodb 3.6.0`, no upgrade path until upstream).
2. **Follow-up fixes A–E** — five issues caught in the v0.11.0 follow-up review. Three were bugs in the v0.11.0 features themselves (\`test_support\` was unusable from external consumers); two were design regressions where the original Batch 1 fix went too far.

## Issue map (this PR)

| Issue | Fix | Commits |
|---|---|---|
| **(audit)** RUSTSEC-2026-0118/0119 | Ignore both with comment pointing at mongo-rust-driver upstream | \`476e030\` |
| **C** \`ensure_migrations_run\` had a compile-time path baked into the wrong crate | Take \`migrations_dir: &Path\` at runtime via \`Migrator::new\` | \`73375de\` |
| **D** \`spawn_with_listener\` factory was sync-only, didn't compose with real async \`build_server\` | Accept \`FnOnce(TcpListener) -> impl Future<Output = io::Result<Server>>\` | \`486870a\` |
| **E** Claims test-token recipe not discoverable on docs.rs | Module-level rustdoc, expanded \`token_type\` field doc | \`d8af001\` |
| **A+B partial** \`controller:\` on custom endpoints fully rejected; tenant scoping must be hand-rolled | Allow \`before:\` on custom endpoints (auto-populates \`tenant_id\`, \`user\`, \`session\`, \`response_extras\`, \`headers\`); stash \`Context\` in \`req.extensions()\`; reject \`after:\` only (focused error explains the response-shape limitation) | \`848b10b\`, \`318b02c\`, \`9408bd7\` |

\`after:\` on custom endpoints stays rejected — it needs a real design conversation about the response-shape contract (custom handlers return \`HttpResponse\` opaque). That goes in v0.12 with proper brainstorming.

## Why one PR

v0.11.0 has not yet shipped to crates.io — both prior auto-release attempts failed. Bundling A–E into the unblocking PR means a single merge produces a clean v0.11.0 release with no immediate v0.11.1 patch chasing it.

## Quality gate

- \`cargo fmt --all -- --check\` — clean.
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean.
- \`cargo audit\` — clean (with the new ignores).
- \`cargo test --workspace --features test-support\` — all unit/snapshot/CLI tests pass; only pre-existing 44 \`PoolTimedOut\` DB-required failures remain (unchanged from \`main\`).

## Test plan

- [x] Audit passes locally with the ignore.
- [x] \`ensure_migrations_run\` signature now takes a \`&Path\` — verified by reading the runtime API; old callsites updated.
- [x] \`spawn_with_listener\` accepts both sync (\`|l| std::future::ready(...)\`) and async (\`|l| async move { ... }\`) factories — covered by the existing two unit tests after wrapping.
- [x] New \`Claims\` rustdoc example compiles (\`cargo test --doc auth::\` passes).
- [x] Validator: \`controller: { before: ... }\` on a custom endpoint is allowed; \`controller: { after: ... }\` on a custom endpoint produces \`E0312\`-style error.
- [x] Runtime: dispatching a custom endpoint with a \`before:\` controller builds a Context with auto-populated \`tenant_id\` from the auth subject, runs the hook, and stashes the result in \`req.extensions()\` (5 new unit tests).
- [ ] Auto-release re-runs on merge and ships v0.11.0.

## Followups (out of scope here)

- After-hook on custom endpoints — needs a design conversation about response-shape contracts (v0.12).
- Bootstrap-into-runtime auto-scaffold for \`shaperail init\` — was scoped out of #73 too, still a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)