### PR TITLE
v0.11.1 patch — fix v0.11.0 follow-up issues A–E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - **`database:` (singular) config block removed** from `shaperail.config.yaml`. The block was parsed by `ProjectConfig` but never read at runtime — the runtime only ever consumed `databases:` (plural) or `DATABASE_URL`. Configs that retain the legacy block now fail to parse with a clear `unknown field 'database'` error. Migrate by replacing the block with `databases.default:` (preferred — see the new `shaperail init` template) or by relying on `DATABASE_URL` from `.env`. The `DatabaseConfig` type is also removed from `shaperail-core`.
-- **`controller:` declared on a non-CRUD (custom) endpoint is now rejected** at validation time (`shaperail check`). The old behavior was a silent no-op — the runtime dispatched custom endpoints via `handler:` only and never invoked declared controllers. Move shared logic into the custom handler itself; use `shaperail_runtime::auth::Subject` for auth and tenant scoping (#1).
+- **`controller: { after: ... }` declared on a non-CRUD (custom) endpoint is now rejected** at validation time (`shaperail check`). The old behavior was a silent no-op — the runtime dispatched custom endpoints via `handler:` only and never invoked declared controllers. `controller: { before: ... }` is now supported on custom endpoints: the runtime builds a `Context` with auto-populated `tenant_id`, dispatches the before-hook, and stashes the result in `req.extensions_mut()` so the handler can read it via `req.extensions().get::<Context>()`. For purely manual tenant scoping, use `shaperail_runtime::auth::Subject` directly (#1).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,36 @@ All notable changes to Shaperail will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-05-02
+
+Patch release fixing five issues caught in the v0.11.0 follow-up review. The headline runtime additions from v0.11.0 (`test_support`, `Context.session`/`response_extras`, `Subject`) are unchanged in semantics; this release fixes bugs and design regressions in those features.
+
+### Added
+
+- **`controller: { before: ... }` is now supported on custom (non-CRUD) endpoints.** The runtime builds a `Context` with auto-populated `tenant_id` (from the auth subject + the resource's `tenant_key`), dispatches the before-hook, and stashes the resulting Context into `req.extensions_mut()` via `extensions_mut().insert(ctx)`. The custom handler can then read it: `req.extensions().get::<shaperail_runtime::handlers::controller::Context>().cloned()`. This eliminates the most common cross-tenant data-access bug class in custom handlers (forgetting to scope by `tenant_id`). `controller: { after: ... }` on custom endpoints remains rejected — custom handlers own their response shape, so the runtime has no place to merge `response_extras`. (Issues A and B in the v0.11.0 follow-up review, refining #1.)
+
+### Changed (breaking, pre-1.0 cargo audit)
+
+- **`shaperail_runtime::test_support::ensure_migrations_run` signature** now takes `migrations_dir: &Path`. The previous signature used the compile-time `sqlx::migrate!("../migrations")` macro, which baked in `shaperail-runtime`'s manifest dir at *its* compile time — so the function was effectively unusable from any external consumer (Issue C). The new signature uses the runtime `Migrator::new` API: pass `Path::new("./migrations")` from your crate root, or `concat!(env!("CARGO_MANIFEST_DIR"), "/migrations")` for absolute resolution.
+- **`shaperail_runtime::test_support::spawn_with_listener` factory contract** now accepts an async closure: `FnOnce(TcpListener) -> impl Future<Output = io::Result<Server>>`. The previous synchronous contract didn't compose with realistic `build_server` functions that connect a sqlx pool, generate OpenAPI, build registries, etc. (Issue D). Sync factories still work via `|l| std::future::ready(sync_build(l))`.
+
+### Fixed
+
+- **`Claims` test-token recipe is now discoverable on docs.rs.** The "Minting a test token" example was previously inside the struct rustdoc; it now also appears as a module-level doc on `shaperail_runtime::auth::jwt`, which renders at the top of the rendered module page. The `token_type` field doc additionally spells out the "must equal `\"access\"` for protected requests → 401" rule (Issue E).
+
+### Migration
+
+- Anyone calling `ensure_migrations_run(&pool)` must add the `migrations_dir` argument: `ensure_migrations_run(&pool, Path::new("./migrations"))`.
+- Anyone calling `spawn_with_listener(listener, |l| sync_build(l))` must wrap the factory: `spawn_with_listener(listener, |l| async move { sync_build(l) })` or `|l| std::future::ready(sync_build(l))`.
+
+In practice, the v0.11.0 versions of both functions were broken-by-design for the use cases they advertised, so existing code is unlikely to depend on them.
+
 ## [0.11.0] - 2026-05-02
 
 ### Breaking
 
 - **`database:` (singular) config block removed** from `shaperail.config.yaml`. The block was parsed by `ProjectConfig` but never read at runtime — the runtime only ever consumed `databases:` (plural) or `DATABASE_URL`. Configs that retain the legacy block now fail to parse with a clear `unknown field 'database'` error. Migrate by replacing the block with `databases.default:` (preferred — see the new `shaperail init` template) or by relying on `DATABASE_URL` from `.env`. The `DatabaseConfig` type is also removed from `shaperail-core`.
-- **`controller: { after: ... }` declared on a non-CRUD (custom) endpoint is now rejected** at validation time (`shaperail check`). The old behavior was a silent no-op — the runtime dispatched custom endpoints via `handler:` only and never invoked declared controllers. `controller: { before: ... }` is now supported on custom endpoints: the runtime builds a `Context` with auto-populated `tenant_id`, dispatches the before-hook, and stashes the result in `req.extensions_mut()` so the handler can read it via `req.extensions().get::<Context>()`. For purely manual tenant scoping, use `shaperail_runtime::auth::Subject` directly (#1).
+- **`controller:` declared on a non-CRUD (custom) endpoint is now rejected** at validation time (`shaperail check`). The old behavior was a silent no-op — the runtime dispatched custom endpoints via `handler:` only and never invoked declared controllers. Move shared logic into the custom handler itself; use `shaperail_runtime::auth::Subject` for auth and tenant scoping (#1). (v0.11.1 partially relaxes this: `controller: { before: ... }` is now supported on custom endpoints.)
 
 ### Added
 
@@ -236,3 +260,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.10.0]: https://github.com/shaperail/shaperail/releases/tag/v0.10.0
 [0.10.1]: https://github.com/shaperail/shaperail/releases/tag/v0.10.1
 [0.11.0]: https://github.com/shaperail/shaperail/releases/tag/v0.11.0
+[0.11.1]: https://github.com/shaperail/shaperail/releases/tag/v0.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-codegen"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "indexmap",
  "insta",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-runtime"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "actix-multipart",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shaperail-core", "shaperail-codegen", "shaperail-runtime", "shaperai
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/agent_docs/custom-handlers.md
+++ b/agent_docs/custom-handlers.md
@@ -9,7 +9,9 @@ Unlike CRUD endpoints, custom handlers do **not** inherit:
 - Automatic input validation against the resource's `schema:` and the endpoint's `input:`.
 - Automatic tenant isolation (`WHERE tenant_key = $tenant`).
 - Automatic event emission (`events:`).
-- The before/after controller pipeline (`controller: { before, after }`). Declaring `controller:` on a custom endpoint is a validation error in v0.11+.
+- The full before/after controller pipeline. Specifically:
+  - `controller: { before: <name> }` IS supported on custom endpoints (see the section below).
+  - `controller: { after: <name> }` is a validation error on custom endpoints — custom handlers own their response shape, so there is no place to merge `ctx.response_extras` after they return.
 
 You write that logic explicitly inside the handler.
 
@@ -61,9 +63,55 @@ pub async fn regenerate_secret(
 
 For post-fetch checks (read-then-validate flows), use `assert_tenant_match(record_tenant_id)` instead.
 
+## Auto-populating tenant context via `controller: { before: ... }`
+
+If you declare a `before:` controller on a custom endpoint, the runtime
+runs the same hook pipeline as CRUD endpoints get and stashes the resulting
+`Context` into the request's actix extensions. Your handler can read
+`tenant_id`, `user`, `session`, and `response_extras` from there:
+
+```yaml
+# resources/agents.yaml
+endpoints:
+  regenerate_secret:
+    method: POST
+    path: /agents/:id/regenerate_secret
+    auth: [super_admin, admin]
+    controller: { before: prepare_secret_rotation }
+    handler: regenerate_secret
+```
+
+```rust
+// resources/agents.controller.rs — runs before the handler
+pub async fn prepare_secret_rotation(ctx: &mut Context) -> ControllerResult {
+    // ctx.tenant_id is already populated; use it for cross-handler logic.
+    // Stash anything you want the handler to see in ctx.session.
+    ctx.session.insert("rotation_started_at".into(), json!(chrono::Utc::now()));
+    Ok(())
+}
+
+// resources/agents.handlers.rs — runs after the before-controller
+pub async fn regenerate_secret(
+    req: HttpRequest,
+    state: Arc<AppState>,
+    _resource: Arc<ResourceDefinition>,
+    _endpoint: Arc<EndpointSpec>,
+) -> HttpResponse {
+    use shaperail_runtime::handlers::controller::Context;
+    let ctx = req.extensions().get::<Context>().cloned();
+    let tenant = ctx.as_ref().and_then(|c| c.tenant_id.as_deref());
+    // ... use tenant for SQL scoping ...
+}
+```
+
+`after:` controllers are NOT supported on custom endpoints because the
+custom handler owns the response shape — there's no `data:` envelope for
+the runtime to merge `response_extras` into. If your logic needs an
+after-pass, factor it into a helper called from the handler.
+
 ## Sharing logic across custom handlers
 
-There is no controller pipeline for custom endpoints — that's why declaring `controller:` on a custom endpoint is rejected. Share logic the normal Rust way: extract a helper function in `resources/<name>.handlers.rs` and call it from each handler. The framework's job is to give you `Subject` and the runtime's `AppState`; your job is to use them.
+For endpoints without a before-controller, share logic the normal Rust way: extract a helper function in `resources/<name>.handlers.rs` and call it from each handler. The framework's job is to give you `Subject` and the runtime's `AppState`; your job is to use them.
 
 ## What if I want CRUD-style hooks?
 

--- a/agent_docs/testing-strategy.md
+++ b/agent_docs/testing-strategy.md
@@ -142,7 +142,7 @@ async fn health_responds_200() {
 }
 ```
 
-`spawn_with_listener` returns a `TestServer` whose `Drop` aborts the spawned task. For database-backed tests, run migrations once per process via `shaperail_runtime::test_support::ensure_migrations_run(&pool).await?` — the helper uses a `tokio::sync::OnceCell` so parallel tests share a single sweep instead of contending on the migration advisory lock.
+`spawn_with_listener` returns a `TestServer` whose `Drop` aborts the spawned task. For database-backed tests, run migrations once per process via `shaperail_runtime::test_support::ensure_migrations_run(&pool, migrations_dir).await?` — the helper uses a `tokio::sync::OnceCell` so parallel tests share a single sweep instead of contending on the migration advisory lock. Pass the consumer's own migrations directory (e.g. `Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations"))`); the runtime `Migrator::new` API resolves the path at runtime rather than at macro-expansion time, so the path always points at the consumer's migrations even when called through the helper crate.
 
 Future versions of `shaperail init` will generate this lib/bin split for you. Until then, the manual lift above is a one-time edit per project.
 

--- a/agent_docs/testing-strategy.md
+++ b/agent_docs/testing-strategy.md
@@ -95,13 +95,13 @@ shaperail-runtime = { workspace = true, features = ["test-support"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 ```
 
-**`src/lib.rs`** — extract the existing bootstrap into a function that takes a `TcpListener` and returns the unawaited `actix_web::dev::Server`:
+**`src/lib.rs`** — extract the existing bootstrap into an async function that takes a `TcpListener` and returns the unawaited `actix_web::dev::Server`. The function is async because realistic bootstrap code connects a sqlx pool, generates OpenAPI docs, builds resource registries, etc.:
 
 ```rust
 use std::net::TcpListener;
 use actix_web::dev::Server;
 
-pub fn build_server(listener: TcpListener) -> std::io::Result<Server> {
+pub async fn build_server(listener: TcpListener) -> std::io::Result<Server> {
     // ... your existing bootstrap (config, pool, registry, channels, etc.) ...
     let server = HttpServer::new(move || { /* ... */ })
         .listen(listener)?
@@ -119,7 +119,7 @@ use std::net::TcpListener;
 async fn main() -> std::io::Result<()> {
     let port: u16 = std::env::var("PORT").ok().and_then(|v| v.parse().ok()).unwrap_or(3000);
     let listener = TcpListener::bind(("0.0.0.0", port))?;
-    my_app::build_server(listener)?.await
+    my_app::build_server(listener).await?.await
 }
 ```
 
@@ -133,7 +133,7 @@ async fn health_responds_200() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let server = shaperail_runtime::test_support::spawn_with_listener(
         listener,
-        my_app::build_server,
+        |l| async move { my_app::build_server(l).await },
     )
     .await
     .unwrap();

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ description: Deterministic Rust backend generation from explicit YAML resources.
 url: https://shaperail.io
 baseurl: ""
 repository: shaperail/shaperail
-release_version: 0.11.0
+release_version: 0.11.1
 markdown: kramdown
 permalink: pretty
 remote_theme: just-the-docs/just-the-docs@v0.12.0

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -212,6 +212,16 @@ CRUD actions) do **not** get automatic tenant isolation — the framework cannot
 infer your data flow. Use the `Subject` API in `shaperail_runtime::auth` to
 extract the role/tenant and apply scoping explicitly:
 
+### Cleaner alternative: a `before:` controller
+
+If you declare `controller: { before: ... }` on the endpoint, the runtime
+auto-populates `ctx.tenant_id` from the auth subject and the resource's
+`tenant_key`, runs your before-hook, and stashes the resulting Context
+in the request extensions. Your handler reads tenant context from there
+without manually calling `Subject::from_request`. See
+[Custom handlers](../agent_docs/custom-handlers.md)
+for the full pattern.
+
 ~~~rust
 use shaperail_runtime::auth::Subject;
 use sqlx::{Postgres, QueryBuilder};

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -915,16 +915,18 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 ### Step 2 — expose `build_server` from `src/lib.rs`
 
 Move the existing bootstrap logic (config, pool, registry, route registration)
-into a public function that accepts a `TcpListener` and returns the unawaited
-`actix_web::dev::Server`:
+into a public async function that accepts a `TcpListener` and returns the
+unawaited `actix_web::dev::Server`. The function is async because realistic
+bootstrap code connects a sqlx pool, generates OpenAPI docs, builds resource
+registries, etc., all of which are async operations:
 
 ```rust
 // src/lib.rs
 use std::net::TcpListener;
 use actix_web::dev::Server;
 
-pub fn build_server(listener: TcpListener) -> std::io::Result<Server> {
-    // ... config, pool setup, resource registry, middleware ...
+pub async fn build_server(listener: TcpListener) -> std::io::Result<Server> {
+    // ... async config, pool setup, resource registry, middleware ...
     let server = actix_web::HttpServer::new(move || {
         // ... App::new().route(...) ...
     })
@@ -962,7 +964,7 @@ async fn health_responds_200() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let server = shaperail_runtime::test_support::spawn_with_listener(
         listener,
-        my_app::build_server,
+        |l| async move { my_app::build_server(l).await },
     )
     .await
     .unwrap();
@@ -970,6 +972,17 @@ async fn health_responds_200() {
     let resp = reqwest::get(server.url("/health")).await.unwrap();
     assert_eq!(resp.status(), 200);
 }
+```
+
+If your `build_server` is synchronous (no async work in bootstrap), wrap it:
+
+```rust
+    let server = shaperail_runtime::test_support::spawn_with_listener(
+        listener,
+        |l| async move { my_app::build_server(l) },
+    )
+    .await
+    .unwrap();
 ```
 
 `spawn_with_listener` binds to port 0 (OS assigns an ephemeral port) and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -981,14 +981,20 @@ multiple server instances will each get a unique port with no conflicts.
 For database-backed integration tests, call `ensure_migrations_run` before your
 first query. The helper is gated on a `tokio::sync::OnceCell`, so parallel
 tests share a single migration sweep instead of contending on the Postgres
-advisory lock:
+advisory lock.
+
+Pass the path to your project's own `migrations/` directory. Use
+`std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations"))` for
+an absolute path that works regardless of where `cargo test` is invoked from:
 
 ```rust
+use std::path::Path;
 use shaperail_runtime::test_support::ensure_migrations_run;
 
 #[tokio::test]
 async fn test_create_user(pool: sqlx::PgPool) {
-    ensure_migrations_run(&pool).await.expect("migrations");
+    let migrations = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations"));
+    ensure_migrations_run(&pool, migrations).await.expect("migrations");
     // ... test body ...
 }
 ```

--- a/shaperail-cli/Cargo.toml
+++ b/shaperail-cli/Cargo.toml
@@ -15,9 +15,9 @@ name = "shaperail"
 path = "src/main.rs"
 
 [dependencies]
-shaperail-codegen = { version = "0.11.0", path = "../shaperail-codegen" }
-shaperail-core = { version = "0.11.0", path = "../shaperail-core" }
-shaperail-runtime = { version = "0.11.0", path = "../shaperail-runtime" }
+shaperail-codegen = { version = "0.11.1", path = "../shaperail-codegen" }
+shaperail-core = { version = "0.11.1", path = "../shaperail-core" }
+shaperail-runtime = { version = "0.11.1", path = "../shaperail-runtime" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/shaperail-codegen/Cargo.toml
+++ b/shaperail-codegen/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-shaperail-core = { version = "0.11.0", path = "../shaperail-core" }
+shaperail-core = { version = "0.11.1", path = "../shaperail-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/shaperail-codegen/src/validator.rs
+++ b/shaperail-codegen/src/validator.rs
@@ -413,11 +413,16 @@ pub fn validate_resource(rd: &ResourceDefinition) -> Vec<ValidationError> {
     errors
 }
 
-/// Rejects `controller:` declarations on non-CRUD (custom) endpoints.
+/// Rejects `controller: { after: ... }` declarations on non-CRUD (custom) endpoints.
 ///
-/// `controller:` is dispatched exclusively by the CRUD pipeline. Custom endpoints
-/// use `handler:` and own their own request/response flow — declaring a controller
-/// on them was previously a silent no-op. Now it is a hard validation error.
+/// `before:` controllers are now permitted on custom endpoints — the runtime builds
+/// a `Context` with auto-populated `tenant_id`, dispatches the before-hook, and
+/// stashes the resulting `Context` into `req.extensions_mut()` so the custom handler
+/// can read it.
+///
+/// `after:` controllers remain rejected on custom endpoints because the custom handler
+/// owns the response shape — there is no `data:` envelope for the runtime to merge
+/// `ctx.response_extras` into, and no consistent hook point after the handler returns.
 fn validate_controller_only_on_crud(
     resource: &str,
     action: &str,
@@ -432,13 +437,26 @@ fn validate_controller_only_on_crud(
         "bulk_create",
         "bulk_delete",
     ];
-    if !CRUD_ACTIONS.contains(&action) && endpoint.controller.is_some() {
+    if CRUD_ACTIONS.contains(&action) {
+        return None;
+    }
+    // Custom endpoint: allow before-only controller, reject after-controller.
+    let has_after = endpoint
+        .controller
+        .as_ref()
+        .and_then(|c| c.after.as_deref())
+        .is_some();
+    if has_after {
         return Some(err(&format!(
-            "resource '{resource}': endpoint '{action}' declares `controller:` but is a custom \
-             endpoint (dispatched via `handler:`). `controller` is only valid on conventional CRUD \
-             endpoints (list / get / create / update / delete / bulk_create / bulk_delete). For \
-             shared logic on custom handlers, use the typed `Subject` and tenant helpers from \
-             `shaperail_runtime::auth` directly inside your handler."
+            "resource '{resource}': endpoint '{action}' declares `controller: {{ after: ... }}`, \
+             but `after:` controllers are only valid on conventional CRUD endpoints \
+             (list / get / create / update / delete / bulk_create / bulk_delete).\n\
+             \n\
+             Custom endpoints generate their own response via `handler:`, so the runtime \
+             has no place to merge `ctx.response_extras` or pass through after-hook \
+             mutations. Use a `before:` controller for shared setup (auth augmentation, \
+             tenant scoping, request validation), and put response-shaping logic inside \
+             the handler itself."
         )));
     }
     None
@@ -957,7 +975,31 @@ schema:
     }
 
     #[test]
-    fn reject_controller_on_custom_endpoint() {
+    fn reject_after_controller_on_custom_endpoint() {
+        let yaml = r#"
+resource: agents
+version: 1
+schema:
+  id: { type: uuid, primary: true, generated: true }
+endpoints:
+  regenerate_secret:
+    method: POST
+    path: /agents/:id/regenerate_secret
+    auth: [admin]
+    controller: { after: my_after }
+"#;
+        let rd = parse_resource(yaml).unwrap();
+        let errors = validate_resource(&rd);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("declares `controller: { after: ... }`")),
+            "expected a CustomEndpointWithAfterController error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn allow_before_controller_on_custom_endpoint() {
         let yaml = r#"
 resource: agents
 version: 1
@@ -973,10 +1015,8 @@ endpoints:
         let rd = parse_resource(yaml).unwrap();
         let errors = validate_resource(&rd);
         assert!(
-            errors.iter().any(|e| e
-                .message
-                .contains("declares `controller:` but is a custom endpoint")),
-            "expected a CustomEndpointWithController error, got: {errors:?}"
+            errors.is_empty(),
+            "before:-only controller on a custom endpoint should validate clean, got: {errors:?}"
         );
     }
 

--- a/shaperail-runtime/Cargo.toml
+++ b/shaperail-runtime/Cargo.toml
@@ -20,7 +20,7 @@ observability-otlp = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:ope
 test-support = []
 
 [dependencies]
-shaperail-core = { version = "0.11.0", path = "../shaperail-core" }
+shaperail-core = { version = "0.11.1", path = "../shaperail-core" }
 actix-web = { workspace = true }
 actix-ws = { workspace = true }
 actix-multipart = { workspace = true }

--- a/shaperail-runtime/src/auth/jwt.rs
+++ b/shaperail-runtime/src/auth/jwt.rs
@@ -1,3 +1,29 @@
+//! HS256 JWT signing and validation for Shaperail's auth middleware.
+//!
+//! # Minting a test token
+//!
+//! ```rust,no_run
+//! use shaperail_runtime::auth::JwtConfig;
+//!
+//! let config = JwtConfig::new("test-secret-at-least-32-bytes-long!", 3600, 86400);
+//! let token = config
+//!     .encode_access_with_tenant(
+//!         "00000000-0000-0000-0000-000000000001",
+//!         "admin",
+//!         Some("org-1"),
+//!     )
+//!     .unwrap();
+//! // Send as `Authorization: Bearer {token}` on any protected request.
+//! ```
+//!
+//! # Common rejection reasons (logged via `tracing::warn!`)
+//!
+//! - `JWT rejected: decode failed` — signature mismatch, expired, malformed.
+//! - `JWT rejected: token_type must be "access"` — refresh token sent against
+//!   a protected endpoint.
+//!
+//! See [`Claims`] for the canonical claim shape.
+
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
@@ -41,7 +67,10 @@ pub struct Claims {
     pub iat: i64,
     /// Expiration (unix timestamp).
     pub exp: i64,
-    /// Token type: "access" or "refresh".
+    /// Token type. Must equal `"access"` to authorize a protected request —
+    /// any other value (including `"refresh"`) is rejected with 401, accompanied
+    /// by a `tracing::warn!` line. The runtime mints `"refresh"` tokens only
+    /// for the refresh endpoint.
     #[serde(default = "default_token_type")]
     pub token_type: String,
     /// Tenant ID (M18). Optional — present when multi-tenancy is enabled.

--- a/shaperail-runtime/src/handlers/controller.rs
+++ b/shaperail-runtime/src/handlers/controller.rs
@@ -47,6 +47,7 @@ use crate::plugins::{PluginContext, PluginUser, WasmRuntime};
 ///     Ok(())
 /// }
 /// ```
+#[derive(Clone)]
 pub struct Context {
     /// Mutable input data. Before-controllers can modify what gets written to DB.
     pub input: serde_json::Map<String, serde_json::Value>,

--- a/shaperail-runtime/src/handlers/crud.rs
+++ b/shaperail-runtime/src/handlers/crud.rs
@@ -127,7 +127,7 @@ fn user_role_for_cache(user: Option<&AuthenticatedUser>) -> &str {
 
 /// Returns the tenant_id for the current request, if the resource has `tenant_key` set
 /// and the user has a `tenant_id` claim.
-fn resolve_tenant_id(
+pub(crate) fn resolve_tenant_id(
     resource: &ResourceDefinition,
     user: Option<&AuthenticatedUser>,
 ) -> Option<String> {

--- a/shaperail-runtime/src/handlers/routes.rs
+++ b/shaperail-runtime/src/handlers/routes.rs
@@ -285,3 +285,188 @@ pub fn register_all_resources(
         register_resource(cfg, resource, state.clone());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use actix_web::HttpMessage;
+    use indexmap::IndexMap;
+    use shaperail_core::{FieldSchema, FieldType, ResourceDefinition};
+
+    use super::super::controller::Context;
+    use super::super::crud::resolve_tenant_id;
+    use crate::auth::extractor::AuthenticatedUser;
+
+    fn test_pool() -> sqlx::PgPool {
+        sqlx::PgPool::connect_lazy("postgres://localhost/test").unwrap()
+    }
+
+    fn user_with_tenant(tenant_id: &str) -> AuthenticatedUser {
+        AuthenticatedUser {
+            id: "user-1".to_string(),
+            role: "member".to_string(),
+            tenant_id: Some(tenant_id.to_string()),
+        }
+    }
+
+    fn uuid_field() -> FieldSchema {
+        FieldSchema {
+            field_type: FieldType::Uuid,
+            primary: true,
+            generated: true,
+            required: false,
+            unique: false,
+            nullable: false,
+            reference: None,
+            min: None,
+            max: None,
+            format: None,
+            values: None,
+            default: None,
+            sensitive: false,
+            search: false,
+            items: None,
+            transient: false,
+        }
+    }
+
+    fn fk_field() -> FieldSchema {
+        FieldSchema {
+            field_type: FieldType::Uuid,
+            primary: false,
+            generated: false,
+            required: true,
+            unique: false,
+            nullable: false,
+            reference: Some("organizations.id".to_string()),
+            min: None,
+            max: None,
+            format: None,
+            values: None,
+            default: None,
+            sensitive: false,
+            search: false,
+            items: None,
+            transient: false,
+        }
+    }
+
+    fn resource_with_tenant_key(tenant_key: &str) -> ResourceDefinition {
+        let mut schema = IndexMap::new();
+        schema.insert("id".to_string(), uuid_field());
+        schema.insert(tenant_key.to_string(), fk_field());
+        ResourceDefinition {
+            resource: "agents".to_string(),
+            version: 1,
+            db: None,
+            tenant_key: Some(tenant_key.to_string()),
+            schema,
+            endpoints: None,
+            relations: None,
+            indexes: None,
+        }
+    }
+
+    fn resource_without_tenant_key() -> ResourceDefinition {
+        let mut schema = IndexMap::new();
+        schema.insert("id".to_string(), uuid_field());
+        ResourceDefinition {
+            resource: "agents".to_string(),
+            version: 1,
+            db: None,
+            tenant_key: None,
+            schema,
+            endpoints: None,
+            relations: None,
+            indexes: None,
+        }
+    }
+
+    // --- resolve_tenant_id behavior ---
+
+    #[test]
+    fn resolve_tenant_id_populates_from_user_when_resource_has_tenant_key() {
+        let resource = resource_with_tenant_key("org_id");
+        let user = user_with_tenant("org-abc");
+        let tenant_id = resolve_tenant_id(&resource, Some(&user));
+        assert_eq!(tenant_id, Some("org-abc".to_string()));
+    }
+
+    #[test]
+    fn resolve_tenant_id_is_none_when_resource_has_no_tenant_key() {
+        let resource = resource_without_tenant_key();
+        let user = user_with_tenant("org-abc");
+        // Even though the user carries a tenant claim, no tenant_key → no scoping.
+        let tenant_id = resolve_tenant_id(&resource, Some(&user));
+        assert_eq!(tenant_id, None);
+    }
+
+    #[test]
+    fn resolve_tenant_id_is_none_when_user_has_no_tenant_claim() {
+        let resource = resource_with_tenant_key("org_id");
+        let user = AuthenticatedUser {
+            id: "user-1".to_string(),
+            role: "super_admin".to_string(),
+            tenant_id: None,
+        };
+        let tenant_id = resolve_tenant_id(&resource, Some(&user));
+        assert_eq!(tenant_id, None);
+    }
+
+    // --- Context: Clone + actix extensions round-trip ---
+
+    #[tokio::test]
+    async fn context_clone_round_trips_through_extensions() {
+        // Build a Context with tenant_id and a session entry.
+        let mut ctx = Context {
+            input: serde_json::Map::new(),
+            data: None,
+            user: Some(user_with_tenant("org-1")),
+            pool: test_pool(),
+            headers: HashMap::new(),
+            response_headers: vec![],
+            tenant_id: Some("org-1".to_string()),
+            session: serde_json::Map::new(),
+            response_extras: serde_json::Map::new(),
+        };
+        ctx.session
+            .insert("ran".to_string(), serde_json::json!(true));
+
+        // Simulate what routes.rs does: stash the context in the extensions of a
+        // minimal actix HttpRequest built from scratch.
+        let req = actix_web::test::TestRequest::post()
+            .uri("/agents/1/regenerate_secret")
+            .to_http_request();
+        req.extensions_mut().insert(ctx);
+
+        // Now simulate what the custom handler does: pull it back out.
+        let retrieved = req.extensions().get::<Context>().cloned();
+        assert!(
+            retrieved.is_some(),
+            "Context should be retrievable from extensions"
+        );
+        let ctx_out = retrieved.unwrap();
+        assert_eq!(ctx_out.tenant_id, Some("org-1".to_string()));
+        assert_eq!(ctx_out.session["ran"], serde_json::json!(true));
+        assert!(ctx_out.user.is_some());
+        assert_eq!(
+            ctx_out.user.as_ref().unwrap().tenant_id.as_deref(),
+            Some("org-1")
+        );
+    }
+
+    #[test]
+    fn context_without_before_controller_produces_no_extension() {
+        // When no before-controller is declared the runtime never inserts a Context.
+        // Verify that extensions().get::<Context>() returns None in that case.
+        let req = actix_web::test::TestRequest::get()
+            .uri("/agents")
+            .to_http_request();
+        let ctx = req.extensions().get::<Context>().cloned();
+        assert!(
+            ctx.is_none(),
+            "no Context should be present when no before-controller ran"
+        );
+    }
+}

--- a/shaperail-runtime/src/handlers/routes.rs
+++ b/shaperail-runtime/src/handlers/routes.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use actix_multipart::Multipart;
-use actix_web::{web, HttpRequest};
+use actix_web::{web, HttpMessage, HttpRequest};
 use shaperail_core::{HttpMethod, ResourceDefinition};
 
 use super::crud::{self, AppState};
@@ -194,6 +195,60 @@ pub fn register_resource(
                             let r = r.clone();
                             let action = action_owned.clone();
                             async move {
+                                // If the endpoint declares a before:-controller, build a Context,
+                                // run the hook, and stash the result in req.extensions_mut() so
+                                // the custom handler can read it via
+                                // req.extensions().get::<Context>().
+                                let before_name = ep
+                                    .controller
+                                    .as_ref()
+                                    .and_then(|c| c.before.as_deref())
+                                    .map(|s| s.to_string());
+                                if let Some(before_name) = before_name {
+                                    let user = crate::auth::extractor::try_extract_auth(&req);
+                                    let headers: HashMap<String, String> = req
+                                        .headers()
+                                        .iter()
+                                        .map(|(k, v)| {
+                                            (
+                                                k.to_string(),
+                                                v.to_str().unwrap_or("").to_string(),
+                                            )
+                                        })
+                                        .collect();
+                                    let tenant_id =
+                                        crud::resolve_tenant_id(&r, user.as_ref());
+                                    let mut ctx = super::controller::Context {
+                                        input: serde_json::Map::new(),
+                                        data: None,
+                                        user: user.clone(),
+                                        pool: state.pool.clone(),
+                                        headers,
+                                        response_headers: vec![],
+                                        tenant_id,
+                                        session: serde_json::Map::new(),
+                                        response_extras: serde_json::Map::new(),
+                                    };
+                                    #[cfg(feature = "wasm-plugins")]
+                                    let wasm_rt = state.wasm_runtime.as_ref();
+                                    #[cfg(not(feature = "wasm-plugins"))]
+                                    let wasm_rt: Option<&()> = None;
+                                    if let Err(e) = super::controller::dispatch_controller(
+                                        &before_name,
+                                        &r.resource,
+                                        &mut ctx,
+                                        state.controllers.as_ref(),
+                                        wasm_rt,
+                                    )
+                                    .await
+                                    {
+                                        use actix_web::ResponseError;
+                                        return e.error_response();
+                                    }
+                                    req.extensions_mut()
+                                        .insert(ctx);
+                                }
+
                                 let resource_name = r.resource.clone();
                                 let key = super::custom::handler_key(&resource_name, &action);
                                 let handler = state

--- a/shaperail-runtime/src/test_support.rs
+++ b/shaperail-runtime/src/test_support.rs
@@ -94,23 +94,31 @@ where
     })
 }
 
-/// Runs database migrations exactly once per process, regardless of how many tests
-/// invoke this helper concurrently.
+/// Runs database migrations exactly once per process, regardless of how many
+/// tests invoke this helper concurrently.
 ///
-/// Tests running in parallel typically all want migrations applied before any of
-/// them touches the database. Calling `sqlx::migrate!()` from each test wastes
-/// time and serializes on the migration advisory lock; calling it once via this
-/// helper is O(1) for every subsequent caller.
+/// `migrations_dir` should point at the consumer's own `migrations/` directory.
+/// Use a relative path like `Path::new("./migrations")` from the consumer's
+/// crate root, or an absolute path computed via `env!("CARGO_MANIFEST_DIR")`.
 ///
-/// The migration source is the workspace `migrations/` directory, the same
-/// directory the runtime uses in production.
-pub async fn ensure_migrations_run(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+/// # Why this is not `sqlx::migrate!()`
+///
+/// The compile-time `sqlx::migrate!()` macro resolves its path against the
+/// caller's manifest dir at the macro's expansion site. If a helper crate
+/// expanded the macro, the path would point at that helper's dir, not the
+/// final consumer's. Taking the path at runtime via `Migrator::new` lets the
+/// consumer point at its own migrations.
+pub async fn ensure_migrations_run(
+    pool: &sqlx::PgPool,
+    migrations_dir: &std::path::Path,
+) -> Result<(), sqlx::migrate::MigrateError> {
     use tokio::sync::OnceCell;
     static MIGRATED: OnceCell<()> = OnceCell::const_new();
     MIGRATED
         .get_or_try_init(|| async {
-            sqlx::migrate!("../migrations").run(pool).await?;
-            Ok::<_, sqlx::Error>(())
+            let migrator = sqlx::migrate::Migrator::new(migrations_dir).await?;
+            migrator.run(pool).await?;
+            Ok::<_, sqlx::migrate::MigrateError>(())
         })
         .await?;
     Ok(())

--- a/shaperail-runtime/src/test_support.rs
+++ b/shaperail-runtime/src/test_support.rs
@@ -7,18 +7,16 @@
 //! ```no_run
 //! # use std::net::TcpListener;
 //! # async fn run() -> std::io::Result<()> {
-//! // Provide a factory that builds your `actix_web::dev::Server` from a listener.
 //! let listener = TcpListener::bind("127.0.0.1:0")?;
 //! let server = shaperail_runtime::test_support::spawn_with_listener(
 //!     listener,
-//!     |listener| {
-//!         // Replace with your project's `build_server(listener)`.
+//!     |listener| async move {
+//!         // Replace with your project's async `build_server(listener)`.
 //!         unimplemented!()
 //!     },
 //! )
 //! .await?;
-//! // Hit it via reqwest, etc.
-//! drop(server); // shuts the server down
+//! drop(server);
 //! # Ok(()) }
 //! ```
 
@@ -74,19 +72,24 @@ impl Drop for TestServer {
 
 /// Spawns the server returned by `factory` on `listener` and returns a `TestServer`.
 ///
-/// The factory closure receives the listener (consumed) and must return the configured
-/// `actix_web::dev::Server`. Typical usage: pass your project's `build_server(listener)`
-/// function directly.
-pub async fn spawn_with_listener<F>(
+/// The factory closure receives the listener (consumed) and must return a future
+/// that resolves to the configured `actix_web::dev::Server`. This supports async
+/// factories — the common case — which connect a sqlx pool, generate OpenAPI docs,
+/// build resource registries, etc. before handing back the server.
+///
+/// Sync builders still work via `|l| async move { sync_build(l) }` or
+/// `|l| std::future::ready(sync_build(l))`.
+pub async fn spawn_with_listener<F, Fut>(
     listener: TcpListener,
     factory: F,
 ) -> std::io::Result<TestServer>
 where
-    F: FnOnce(TcpListener) -> std::io::Result<Server> + Send + 'static,
+    F: FnOnce(TcpListener) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = std::io::Result<Server>> + Send + 'static,
 {
     listener.set_nonblocking(true)?;
     let addr = listener.local_addr()?;
-    let server = factory(listener)?;
+    let server = factory(listener).await?;
     let handle = tokio::spawn(server);
     Ok(TestServer {
         addr,
@@ -145,7 +148,7 @@ mod tests {
     async fn spawn_with_listener_returns_bound_address() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let original_port = listener.local_addr().unwrap().port();
-        let server = spawn_with_listener(listener, trivial_factory)
+        let server = spawn_with_listener(listener, |l| async move { trivial_factory(l) })
             .await
             .unwrap();
         assert_eq!(server.port(), original_port);
@@ -155,7 +158,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_with_listener_serves_requests() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let server = spawn_with_listener(listener, trivial_factory)
+        let server = spawn_with_listener(listener, |l| async move { trivial_factory(l) })
             .await
             .unwrap();
         let resp = reqwest::get(server.url("/health")).await.unwrap();


### PR DESCRIPTION
## Why

v0.11.0 shipped at 05:18Z, but the follow-up review surfaced **five issues** caught after merge. Three are bugs in v0.11.0 features I shipped; two are design regressions where the original Batch 1 fix went too far. Bundled into v0.11.1 patch.

The follow-up commits were originally appended to PR #75 (the audit-ignore unblocker), but #75 was merged before they landed — they ended up stranded on a now-detached branch. Cherry-picked here onto a fresh branch from \`main\` for a clean v0.11.0 → v0.11.1 release path.

## Issue map

| Issue | Fix | Commits |
|---|---|---|
| **A+B** \`controller:\` on custom endpoints fully rejected; tenant scoping must be hand-rolled | Allow \`before:\` on custom endpoints (auto-populates \`ctx.tenant_id\`, \`user\`, \`session\`, \`response_extras\`, \`headers\`); stash \`Context\` in \`req.extensions()\`; reject only \`after:\` with a focused error. | \`0627996\`, \`ebe2907\`, \`2136f33\` |
| **C** \`ensure_migrations_run\` had a compile-time path baked into shaperail-runtime's manifest dir; broken for external consumers | Take \`migrations_dir: &Path\` at runtime via \`Migrator::new\` | \`17a842d\` |
| **D** \`spawn_with_listener\` factory was sync-only; doesn't compose with async \`build_server\` | Accept \`FnOnce(TcpListener) -> impl Future<Output = io::Result<Server>>\` | \`86ef014\` |
| **E** Claims test-token recipe not discoverable on docs.rs | Module-level rustdoc on \`auth::jwt\`; expanded \`token_type\` field doc | \`760e191\` |

\`after:\` on custom endpoints stays rejected — designing the response-shape contract belongs in v0.12 with proper brainstorming.

## Breaking-API notes

C and D are technically breaking changes to two functions on the \`test-support\` feature flag. Both functions were broken-by-design in v0.11.0 (the marquee \`test_support\` feature was unusable for the audience it was built for), so existing code is unlikely to depend on the v0.11.0 signatures. Documented under "Migration" in the v0.11.1 CHANGELOG entry.

The CHANGELOG \`[0.11.0]\` section's breaking-change wording is also corrected — the previous wording (added in commit 2136f33 inside the \`fix/hickory-proto-rustsec\` branch) was overwritten when v0.11.0 actually published; this PR restores the published wording and notes the v0.11.1 relaxation in a parenthetical.

## Quality gate

- \`bash .github/scripts/assert-release-version.sh 0.11.1\` — passes (workspace, inter-crate pins, docs/_config.yml, CHANGELOG link reference all aligned).
- \`cargo fmt --all -- --check\` — clean.
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean.
- \`cargo audit\` — clean (the audit-ignore from v0.11.0 still in effect for hickory-proto via mongodb).
- \`cargo test --workspace --features test-support\` — all unit/snapshot/CLI tests pass; only pre-existing 44 \`PoolTimedOut\` DB-required failures remain.

## Test plan

- [x] Full local build clean
- [x] Full clippy clean
- [x] All non-DB tests green
- [x] release-version assertion passes for 0.11.1
- [ ] Auto-release ships v0.11.1 to crates.io + GitHub Releases on merge

## Followups (out of scope here)

- After-hook on custom endpoints — needs the response-shape contract design (v0.12).
- Bootstrap-into-runtime auto-scaffold for \`shaperail init\` — still a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)