### PR TITLE
v0.11.2 patch — custom handlers can now read POST/PUT bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ Thumbs.db
 
 # Docker volumes
 postgres_data/
+
+# Claude Code local state (agents/, commands/, skills/, settings.json stay tracked)
+.claude/scheduled_tasks.lock
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Shaperail will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-05-02
+
+### Fixed
+
+- **Custom handlers can now read the request body.** The custom-endpoint dispatch closure in `shaperail-runtime/src/handlers/routes.rs` had only `(req, state)` in its argument list — actix-web only extracts the request payload when an extractor is declared there, so `ServiceRequest.payload` was dropped before the handler ran and `req.take_payload()` returned `Payload::None` unconditionally. Any custom POST/PUT/PATCH handler trying to read a body got zero bytes regardless of `Content-Length`. The closure now also accepts `body: web::Bytes`; the runtime stashes the buffered bytes in `req.extensions_mut().insert(body)`, and custom handlers read them via `req.extensions().get::<web::Bytes>().cloned()`. Bodies larger than actix's default `PayloadConfig` limit (256 KB) still fail with 413 before the handler runs — configure that at the app level if you need bigger payloads. See `agent_docs/custom-handlers.md` for the full pattern.
+
 ## [0.11.1] - 2026-05-02
 
 Patch release fixing five issues caught in the v0.11.0 follow-up review. The headline runtime additions from v0.11.0 (`test_support`, `Context.session`/`response_extras`, `Subject`) are unchanged in semantics; this release fixes bugs and design regressions in those features.
@@ -261,3 +267,4 @@ In practice, the v0.11.0 versions of both functions were broken-by-design for th
 [0.10.1]: https://github.com/shaperail/shaperail/releases/tag/v0.10.1
 [0.11.0]: https://github.com/shaperail/shaperail/releases/tag/v0.11.0
 [0.11.1]: https://github.com/shaperail/shaperail/releases/tag/v0.11.1
+[0.11.2]: https://github.com/shaperail/shaperail/releases/tag/v0.11.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,3 +175,71 @@ If docs and code disagree, fix the disagreement immediately (AI-First rule).
 - Branch per milestone or feature: `git checkout -b feat/m01-core-types`
 - Only commit when clippy + tests pass
 - Commit format: `feat(shaperail-core): M01 — Core Types`
+- **Never push more commits to a branch with an open PR you intend to merge as-is.** PRs auto-merge as soon as CI is green; follow-up commits frequently land too late and end up stranded on the merged branch. Open a new PR for follow-ups.
+
+## Release Process — FOLLOW EVERY TIME
+
+Releases ship via the `auto-release.yml` workflow on every push to `main`. The workflow checks whether the workspace version is ahead of the latest git tag; if yes, it tests + builds binaries (5 targets including the slow Windows MSVC) + publishes 4 crates to crates.io + creates a GitHub Release. Cross-platform binaries take ~15 minutes; the GitHub Release tag/page only appears at the end.
+
+**Bumping the version requires updating SEVEN places.** `bash .github/scripts/assert-release-version.sh <version>` checks all of them. Run it locally before pushing — if it fails in CI the auto-release aborts and the next merge has to repeat the dance.
+
+The seven places (use this checklist verbatim):
+
+1. `Cargo.toml` — `[workspace.package] version = "X.Y.Z"`
+2. `shaperail-cli/Cargo.toml` — `shaperail-codegen = { version = "X.Y.Z", ... }` (and `shaperail-core`, `shaperail-runtime`)
+3. `shaperail-runtime/Cargo.toml` — `shaperail-core = { version = "X.Y.Z", ... }`
+4. `shaperail-codegen/Cargo.toml` — `shaperail-core = { version = "X.Y.Z", ... }`
+5. `docs/_config.yml` — `release_version: X.Y.Z` (Jekyll site footer; non-obvious; has bitten us)
+6. `CHANGELOG.md` — section heading `## [X.Y.Z] - YYYY-MM-DD`
+7. `CHANGELOG.md` — link reference at bottom: `[X.Y.Z]: https://github.com/shaperail/shaperail/releases/tag/vX.Y.Z`
+
+**Pre-1.0 semver convention this project uses:**
+- Patch (`0.11.0` → `0.11.1`): bug fixes, additive non-breaking features, documentation.
+- Minor (`0.11.x` → `0.12.0`): breaking API or behavior changes (e.g., removing a public field, changing function signatures, validation rules that reject previously-accepted YAML).
+- A change behind an opt-in feature flag (e.g. `test-support`) that nobody could have realistically used yet → patch is acceptable.
+
+**Pre-release verification gate (all must pass before push):**
+
+```
+bash .github/scripts/assert-release-version.sh X.Y.Z
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo audit
+cargo test --workspace --no-fail-fast --features test-support
+```
+
+The 44 `PoolTimedOut` failures in `api_integration` / `db_integration` / `grpc_service_tests` are pre-existing and acceptable when no Postgres is running locally.
+
+**RUSTSEC advisories that block the release** must be either upgraded out (`cargo update -p <crate> --precise <version>`) or ignored in `.cargo/audit.toml` with a comment explaining the upstream block. Do NOT release without addressing them — `cargo audit` is part of the auto-release pipeline.
+
+**CHANGELOG section structure:**
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Breaking
+- ...
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+```
+
+Skip subsections that have no entries. Once a release is published, **never edit its CHANGELOG section** — it's frozen as historical record. New changes go in a new `[X.Y.Z+1]` section above.
+
+**The PR title for a release commit MUST be descriptive of the user-facing change, not "release X.Y.Z".** The auto-merge squash uses the PR title as the commit message; "release X.Y.Z" loses the actual content. Example: `v0.11.2 patch — fix custom-handler body extraction (#issue)`.
+
+**Verifying the release shipped:**
+
+```
+gh run list --workflow auto-release.yml --limit 1   # status: completed/success
+gh release view vX.Y.Z                              # tag exists, all 5 binaries
+cargo install shaperail-cli@X.Y.Z                   # crates.io has it
+```
+
+The first two only succeed once the slowest binary (Windows MSVC) finishes building, which can take up to 15 minutes after merge. crates.io publish happens earlier in the pipeline, so `cargo install` works before the GitHub Release page appears.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-codegen"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "indexmap",
  "insta",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-runtime"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "actix-multipart",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shaperail-core", "shaperail-codegen", "shaperail-runtime", "shaperai
 resolver = "2"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/agent_docs/custom-handlers.md
+++ b/agent_docs/custom-handlers.md
@@ -109,6 +109,42 @@ custom handler owns the response shape — there's no `data:` envelope for
 the runtime to merge `response_extras` into. If your logic needs an
 after-pass, factor it into a helper called from the handler.
 
+## Reading the request body
+
+Custom handlers receive the request body as `actix_web::web::Bytes` stashed in the request extensions — **not** via `req.take_payload()`. The runtime extracts the body up front (so actix doesn't drop it from `ServiceRequest.payload`) and inserts it under `web::Bytes`:
+
+```rust
+use actix_web::{HttpRequest, HttpResponse, web};
+
+pub async fn create_journal_entry(
+    req: HttpRequest,
+    state: actix_web::web::Data<std::sync::Arc<shaperail_runtime::handlers::crud::AppState>>,
+    _resource: std::sync::Arc<shaperail_core::ResourceDefinition>,
+    _endpoint: std::sync::Arc<shaperail_core::EndpointSpec>,
+) -> HttpResponse {
+    // HttpRequest is !Send. Extract from req synchronously, move owned data
+    // into the async block.
+    let body = req
+        .extensions()
+        .get::<web::Bytes>()
+        .cloned()
+        .unwrap_or_default();
+    if body.is_empty() {
+        return HttpResponse::BadRequest().finish();
+    }
+    let payload: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => return HttpResponse::BadRequest().json(serde_json::json!({"error": e.to_string()})),
+    };
+    // ... use `state.pool` and `payload` ...
+    HttpResponse::Created().finish()
+}
+```
+
+`req.take_payload()` and `req.payload()` do **not** work — actix-web only extracts the request payload when an extractor is declared in the dispatch closure's argument list. The runtime declares `body: web::Bytes` there and stashes the result; manually re-reading the underlying stream returns `Payload::None`.
+
+For bodies larger than 256 KB (actix's default `PayloadConfig` limit) the request fails with 413 before the handler runs. Configure a larger limit at the app level outside the framework scaffold if you need bigger payloads.
+
 ## Sharing logic across custom handlers
 
 For endpoints without a before-controller, share logic the normal Rust way: extract a helper function in `resources/<name>.handlers.rs` and call it from each handler. The framework's job is to give you `Subject` and the runtime's `AppState`; your job is to use them.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ description: Deterministic Rust backend generation from explicit YAML resources.
 url: https://shaperail.io
 baseurl: ""
 repository: shaperail/shaperail
-release_version: 0.11.1
+release_version: 0.11.2
 markdown: kramdown
 permalink: pretty
 remote_theme: just-the-docs/just-the-docs@v0.12.0

--- a/shaperail-cli/Cargo.toml
+++ b/shaperail-cli/Cargo.toml
@@ -15,9 +15,9 @@ name = "shaperail"
 path = "src/main.rs"
 
 [dependencies]
-shaperail-codegen = { version = "0.11.1", path = "../shaperail-codegen" }
-shaperail-core = { version = "0.11.1", path = "../shaperail-core" }
-shaperail-runtime = { version = "0.11.1", path = "../shaperail-runtime" }
+shaperail-codegen = { version = "0.11.2", path = "../shaperail-codegen" }
+shaperail-core = { version = "0.11.2", path = "../shaperail-core" }
+shaperail-runtime = { version = "0.11.2", path = "../shaperail-runtime" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/shaperail-codegen/Cargo.toml
+++ b/shaperail-codegen/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-shaperail-core = { version = "0.11.1", path = "../shaperail-core" }
+shaperail-core = { version = "0.11.2", path = "../shaperail-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/shaperail-runtime/Cargo.toml
+++ b/shaperail-runtime/Cargo.toml
@@ -20,7 +20,7 @@ observability-otlp = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:ope
 test-support = []
 
 [dependencies]
-shaperail-core = { version = "0.11.1", path = "../shaperail-core" }
+shaperail-core = { version = "0.11.2", path = "../shaperail-core" }
 actix-web = { workspace = true }
 actix-ws = { workspace = true }
 actix-multipart = { workspace = true }

--- a/shaperail-runtime/src/handlers/routes.rs
+++ b/shaperail-runtime/src/handlers/routes.rs
@@ -190,10 +190,17 @@ pub fn register_resource(
                     };
                     cfg.route(
                         &actix_path,
-                        route.to(move |req: HttpRequest, state: web::Data<Arc<AppState>>| {
+                        route.to(move |req: HttpRequest, body: web::Bytes, state: web::Data<Arc<AppState>>| {
                             let ep = ep.clone();
                             let r = r.clone();
                             let action = action_owned.clone();
+                            // Stash the buffered body in request extensions so the custom handler
+                            // can read it via `req.extensions().get::<web::Bytes>().cloned()`.
+                            // actix-web only extracts the request payload when an extractor is
+                            // declared in the closure's argument list — without `body: web::Bytes`
+                            // here, ServiceRequest.payload is dropped and `req.take_payload()`
+                            // returns Payload::None unconditionally.
+                            req.extensions_mut().insert(body);
                             async move {
                                 // If the endpoint declares a before:-controller, build a Context,
                                 // run the hook, and stash the result in req.extensions_mut() so
@@ -467,6 +474,150 @@ mod tests {
         assert!(
             ctx.is_none(),
             "no Context should be present when no before-controller ran"
+        );
+    }
+
+    // --- Custom-handler body extraction (regression test for v0.11.2) ---
+
+    #[actix_web::test]
+    async fn custom_handler_can_read_request_body() {
+        // Regression test for the v0.11.1 bug: actix-web only extracts the
+        // request payload when an extractor is declared in the closure
+        // argument list. v0.11.1's dispatch closure had only (req, state),
+        // so ServiceRequest.payload was dropped and req.take_payload()
+        // returned Payload::None unconditionally — making POST/PUT custom
+        // handlers unable to read their bodies.
+        //
+        // The fix adds `body: web::Bytes` to the closure and stashes it in
+        // req.extensions_mut() so the handler can read it via
+        // req.extensions().get::<web::Bytes>().cloned().
+        use actix_web::{
+            test::{call_service, init_service, TestRequest},
+            web, App,
+        };
+        use indexmap::IndexMap;
+        use shaperail_core::{
+            EndpointSpec, FieldSchema, FieldType, HttpMethod, ResourceDefinition,
+        };
+        use std::sync::Arc;
+
+        // Resource with a single custom POST endpoint named "echo".
+        let mut endpoints = IndexMap::new();
+        endpoints.insert(
+            "echo".to_string(),
+            EndpointSpec {
+                method: Some(HttpMethod::Post),
+                path: Some("/journal_entries".to_string()),
+                handler: Some("echo_body".to_string()),
+                ..Default::default()
+            },
+        );
+        let mut schema = IndexMap::new();
+        schema.insert(
+            "id".to_string(),
+            FieldSchema {
+                field_type: FieldType::Uuid,
+                primary: true,
+                generated: true,
+                required: false,
+                unique: false,
+                nullable: false,
+                reference: None,
+                min: None,
+                max: None,
+                format: None,
+                values: None,
+                default: None,
+                sensitive: false,
+                search: false,
+                items: None,
+                transient: false,
+            },
+        );
+        let resource = ResourceDefinition {
+            resource: "journal".to_string(),
+            version: 1,
+            db: None,
+            tenant_key: None,
+            schema,
+            endpoints: Some(endpoints),
+            relations: None,
+            indexes: None,
+        };
+
+        // Custom handler reads the body bytes from req.extensions() and
+        // echoes back its length + the content. If the bug were still
+        // present, body_len would be 0 and content would be empty.
+        let handler: super::super::custom::CustomHandlerFn = Arc::new(|req, _state, _r, _ep| {
+            // Extract from req synchronously — HttpRequest contains Rc internally
+            // and is therefore !Send, so it cannot cross an async-await boundary.
+            // Move only owned data (the Bytes) into the async block.
+            let body = req
+                .extensions()
+                .get::<web::Bytes>()
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move {
+                let body_len = body.len();
+                let content = String::from_utf8_lossy(&body).to_string();
+                actix_web::HttpResponse::Ok().json(serde_json::json!({
+                    "body_len": body_len,
+                    "content": content,
+                }))
+            })
+        });
+        let mut custom_handlers: super::super::custom::CustomHandlerMap =
+            std::collections::HashMap::new();
+        custom_handlers.insert(
+            super::super::custom::handler_key("journal", "echo"),
+            handler,
+        );
+
+        let mut state = super::super::crud::AppState::new(test_pool(), vec![resource.clone()]);
+        state.custom_handlers = Some(custom_handlers);
+        let state = Arc::new(state);
+
+        // Spin up the actix App with the routes registered.
+        let app = init_service(
+            App::new()
+                .app_data(web::Data::new(state.clone()))
+                .configure(|cfg| {
+                    super::super::routes::register_resource(cfg, &resource, state.clone());
+                }),
+        )
+        .await;
+
+        // POST a non-trivial JSON body. v0.11.1 would echo body_len: 0;
+        // v0.11.2 must echo the actual posted bytes.
+        let payload = serde_json::json!({"description": "ate lunch", "amount": 12.50});
+        let payload_bytes = serde_json::to_vec(&payload).unwrap();
+        let req = TestRequest::post()
+            .uri("/v1/journal_entries")
+            .insert_header(("content-type", "application/json"))
+            .set_payload(payload_bytes.clone())
+            .to_request();
+        let resp = call_service(&app, req).await;
+        assert!(
+            resp.status().is_success(),
+            "expected 2xx, got {:?}",
+            resp.status()
+        );
+
+        let body = actix_web::test::read_body(resp).await;
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let body_len = parsed["body_len"].as_u64().unwrap_or(0);
+        assert_eq!(
+            body_len as usize,
+            payload_bytes.len(),
+            "custom handler must see the full request body, got {} bytes",
+            body_len
+        );
+        assert!(
+            parsed["content"]
+                .as_str()
+                .unwrap_or("")
+                .contains("ate lunch"),
+            "body content should round-trip; got {parsed:?}"
         );
     }
 }


### PR DESCRIPTION
## Why

In v0.11.1, custom (non-CRUD) endpoints silently dropped their request bodies. POST/PUT/PATCH handlers got \`Payload::None\` from \`req.take_payload()\` regardless of \`Content-Length\` — the body was inaccessible.

**Root cause:** actix-web only extracts \`ServiceRequest.payload\` when an extractor is declared in the dispatch closure's argument list. \`shaperail-runtime/src/handlers/routes.rs:193\` had only \`(req: HttpRequest, state: web::Data<...>)\` — no body extractor — so the payload was dropped before the closure ran. \`HttpRequest::take_payload()\` returns \`Payload::None\` unconditionally in that state (actix-web \`request.rs:475\`).

## Fix

- Add \`body: web::Bytes\` to the dispatch closure signature so actix actually extracts the payload.
- Stash the buffered bytes in \`req.extensions_mut().insert(body)\` — same pattern v0.11.1 already uses for the before-hook \`Context\`.
- Custom handlers read the body via \`req.extensions().get::<web::Bytes>().cloned()\`.
- Public \`CustomHandlerFn\` type stays unchanged; the closure-signature fix is internal to the routing layer.

\`docs/agent_docs/custom-handlers.md\` gains a "Reading the request body" section showing the canonical access pattern (extract from \`req\` synchronously, move owned bytes into the async block — \`HttpRequest\` is \`!Send\`).

## Regression test

\`shaperail-runtime/src/handlers/routes.rs::tests::custom_handler_can_read_request_body\` drives a real POST through \`actix_web::test::init_service\` + \`call_service\` and asserts the handler sees the full \`Content-Length\` worth of bytes. Before the fix this test reads 0 bytes; after, it reads the posted payload.

## CLAUDE.md release-process checklist

Adds a "Release Process — FOLLOW EVERY TIME" section to \`CLAUDE.md\` documenting the seven version-pin sites the \`assert-release-version.sh\` script checks (workspace \`Cargo.toml\`, three inter-crate path/version pins, \`docs/_config.yml\`, CHANGELOG section heading, CHANGELOG link reference) plus the full pre-push verification gate. We've hit release-blocking metadata mismatches in three prior releases; this codifies the checklist.

## Quality gate (all run with the same flags as CI)

- ✅ \`bash .github/scripts/assert-release-version.sh 0.11.2\`
- ✅ \`cargo fmt --check\`
- ✅ \`cargo clippy --locked --workspace --all-targets -- -D warnings\`
- ✅ \`cargo bench --locked --workspace --no-run\`
- ✅ \`cargo build --locked --workspace\`
- ✅ \`cargo audit\`
- ✅ \`cargo test --locked --workspace --features test-support\` — 615 tests pass (+1 new regression test); only the 44 pre-existing \`PoolTimedOut\` failures in \`api_integration\` / \`db_integration\` / \`grpc_service_tests\` remain — those need a live Postgres, which CI provides.

## Test plan

- [x] Build clean
- [x] All non-DB tests green
- [x] release-version assertion passes for 0.11.2
- [x] Audit clean
- [ ] Auto-release ships v0.11.2 to crates.io + GitHub Releases on merge

## Out of scope

- Bodies above 256 KB still hit actix's default \`PayloadConfig\` limit and return 413. Configurable at the \`App\` level — not a framework concern for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)