### PR TITLE
docs: public mirror of v0.11.x custom-handler features + CLAUDE.md public-mirror rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,13 +162,37 @@ shaperail resource create <name> --archetype <type>  # archetypes: basic, user, 
 - agent_docs/release.md           → crates.io publish + GitHub Releases
 
 ## Documentation Rule
-After every code change that alters behavior, CLI commands, APIs, or test
-infrastructure, update the relevant docs BEFORE committing:
-- `docs/` — user-facing documentation (CLI reference, guides, examples)
-- `agent_docs/` — internal developer docs (architecture, testing strategy, milestones)
-- `CLAUDE.md` — if the change affects project-level conventions or workflows
+
+After every code change that alters behavior, CLI commands, APIs, configuration, error semantics, or test infrastructure, update the relevant docs BEFORE committing:
+
+- `docs/` — **user-facing public documentation** (rendered to https://shaperail.io). CLI reference, guides, examples, recipes. Has Jekyll front matter (`title`, `parent`, `nav_order`).
+- `agent_docs/` — **internal developer docs** (architecture, testing strategy, codegen patterns, hooks system). No front matter.
+- `CLAUDE.md` — **project-level conventions and workflows** (this file). Update when the change affects how future Claude sessions should approach the codebase.
 
 If docs and code disagree, fix the disagreement immediately (AI-First rule).
+
+### Public-mirror requirement
+
+`docs/` and `agent_docs/` are not optional alternatives — they're parallel audiences. **Every behavior change documented in `agent_docs/X.md` MUST have a corresponding update in `docs/`**, either in an existing user-facing page or as a new mirror page (`docs/X.md`). The internal note isn't enough; users reading the public site at shaperail.io need the same information in public-voice form.
+
+Concretely, the checklist when you finish a code change:
+
+1. ✅ Code change committed with tests.
+2. ✅ `agent_docs/<relevant>.md` updated.
+3. ✅ **Corresponding `docs/<page>.md` updated** — either an existing page got a new section, or a new mirror page was created with Jekyll front matter. If no public page is appropriate, write a one-line justification in the commit message saying so (very rare — most user-visible changes belong in public docs).
+4. ✅ `CHANGELOG.md` `[Unreleased]` (or current version) section names the change.
+5. ✅ If the change affects a release-process, validation rule, or codebase convention, update `CLAUDE.md`.
+
+Examples of the mirror requirement in action:
+
+| Change | `agent_docs/` page | `docs/` page |
+|---|---|---|
+| New runtime API (`Subject`, `Context.session`, `test_support`) | `agent_docs/auth-claims.md`, `agent_docs/custom-handlers.md`, `agent_docs/testing-strategy.md` | `docs/security.md`, `docs/custom-handlers.md`, `docs/testing.md` |
+| Custom-handler body extraction (v0.11.2) | `agent_docs/custom-handlers.md` "Reading the request body" | `docs/custom-handlers.md` "Reading the request body" + callout in `docs/controllers.md` |
+| New validator rule | `agent_docs/codegen-patterns.md` | inline note in `docs/resource-guide.md` |
+| Breaking config change | `agent_docs/architecture.md` if structural | `docs/configuration.md` migration section |
+
+When unsure where the public version belongs, default to creating a new `docs/<topic>.md` page with the same structure as `agent_docs/<topic>.md`, adapted for end-user voice (less internal jargon, more "how do I do this in my project" framing).
 
 ## Git Workflow
 - Never start new feature work on `main`. Create and switch to a fresh branch first.

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -15,13 +15,12 @@ For background work that should not block the response, use
 
 ---
 
-> **Note:** `controller: { before, after }` is only valid on conventional CRUD
-> endpoints (`list` / `get` / `create` / `update` / `delete` / `bulk_create` /
-> `bulk_delete`). Declaring `controller:` on a custom endpoint (one that uses
-> `handler:`) now fails `shaperail check` with a clear error. For shared logic
-> on custom handlers, use the `Subject` API from `shaperail_runtime::auth`
-> directly inside your handler — see [Multi-tenancy]({{ '/multi-tenancy/' | relative_url }})
-> for the pattern.
+> **Custom endpoints (`handler:`):**
+> - `controller: { before: <name> }` IS supported on custom endpoints (v0.11.1+). The runtime builds a `Context` with auto-populated `tenant_id`, runs the before-hook, and stashes the result in `req.extensions()` so the handler can read it via `req.extensions().get::<Context>().cloned()`.
+> - `controller: { after: <name> }` is rejected at validation time — custom handlers own their response shape, so there is no place for the runtime to merge `response_extras` after the handler returns. Factor after-logic into a helper called from inside the handler.
+> - Custom handlers read the request body via `req.extensions().get::<actix_web::web::Bytes>().cloned()` (v0.11.2+) — `req.take_payload()` returns `Payload::None` because actix doesn't extract the payload unless an extractor is declared in the dispatch closure.
+>
+> See [Custom handlers]({{ '/custom-handlers/' | relative_url }}) for the full pattern.
 
 ## Declaring controllers
 

--- a/docs/custom-handlers.md
+++ b/docs/custom-handlers.md
@@ -1,0 +1,167 @@
+---
+title: Custom Handlers
+parent: Guides
+nav_order: 4
+---
+
+# Custom Handlers
+
+A custom endpoint declares `handler:` (and optionally `method:` / `path:`) instead of using one of the conventional CRUD actions (`list` / `get` / `create` / `update` / `delete` / `bulk_create` / `bulk_delete`). Custom handlers own their own request parsing and response generation — the framework gives you the route binding and authentication, but the rest is your code.
+
+```yaml
+# resources/agents.yaml
+endpoints:
+  regenerate_secret:
+    method: POST
+    path: /agents/:id/regenerate_secret
+    auth: [super_admin, admin]
+    handler: regenerate_secret
+```
+
+---
+
+## What custom handlers do NOT inherit
+
+Unlike CRUD endpoints, custom handlers do **not** get:
+
+- Automatic input validation against the resource's `schema:` and the endpoint's `input:`.
+- Automatic tenant isolation (`WHERE tenant_key = $tenant`).
+- Automatic event emission (`events:`).
+- The full before/after controller pipeline. Specifically:
+  - `controller: { before: <name> }` IS supported (v0.11.1+; see below).
+  - `controller: { after: <name> }` is a validation error — custom handlers own their response shape, so there is no `data:` envelope for the runtime to merge `ctx.response_extras` into. Put after-logic inside the handler itself.
+
+You write that logic explicitly inside the handler.
+
+## Reading the request body
+
+Custom handlers receive the request body as `actix_web::web::Bytes` stashed in the request extensions — **not** via `req.take_payload()`. The runtime extracts the body up front (so actix doesn't drop it from `ServiceRequest.payload`) and inserts it under `web::Bytes`:
+
+```rust
+use actix_web::{HttpRequest, HttpResponse, web};
+
+pub async fn create_journal_entry(
+    req: HttpRequest,
+    state: actix_web::web::Data<std::sync::Arc<shaperail_runtime::handlers::crud::AppState>>,
+    _resource: std::sync::Arc<shaperail_core::ResourceDefinition>,
+    _endpoint: std::sync::Arc<shaperail_core::EndpointSpec>,
+) -> HttpResponse {
+    // HttpRequest is !Send. Extract from req synchronously, move owned data
+    // into the async block.
+    let body = req
+        .extensions()
+        .get::<web::Bytes>()
+        .cloned()
+        .unwrap_or_default();
+    if body.is_empty() {
+        return HttpResponse::BadRequest().finish();
+    }
+    let payload: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => return HttpResponse::BadRequest().json(serde_json::json!({"error": e.to_string()})),
+    };
+    // ... use `state.pool` and `payload` ...
+    HttpResponse::Created().finish()
+}
+```
+
+> `req.take_payload()` and `req.payload()` do **not** work in a Shaperail custom handler. actix-web only extracts the request payload when an extractor is declared in the dispatch closure's argument list. The runtime declares `body: web::Bytes` there and stashes the result; manually re-reading the underlying stream returns `Payload::None`.
+
+For bodies larger than 256 KB (actix's default `PayloadConfig` limit) the request fails with 413 before the handler runs. Configure a larger limit at the app level if you need bigger payloads — that's app-level configuration outside the framework's scaffold.
+
+## Authenticating and tenant-scoping queries
+
+Use `Subject` from `shaperail_runtime::auth`. CRUD endpoints get tenant scoping for free; custom handlers must apply it explicitly because the framework cannot infer your data flow.
+
+```rust
+use actix_web::{HttpRequest, HttpResponse};
+use shaperail_runtime::auth::Subject;
+use sqlx::{Postgres, QueryBuilder};
+
+pub async fn regenerate_secret(
+    req: HttpRequest,
+    state: actix_web::web::Data<std::sync::Arc<shaperail_runtime::handlers::crud::AppState>>,
+    path: actix_web::web::Path<uuid::Uuid>,
+) -> HttpResponse {
+    // 1. Authenticate.
+    let subject = match Subject::from_request(&req) {
+        Ok(s) => s,
+        Err(_) => return HttpResponse::Unauthorized().finish(),
+    };
+
+    // 2. Build a tenant-scoped UPDATE.
+    let agent_id = path.into_inner();
+    let new_hash: &str = ""; // computed earlier
+    let mut q = QueryBuilder::<Postgres>::new("UPDATE agents SET mcp_secret_hash = ");
+    q.push_bind(new_hash);
+    q.push(" WHERE id = ");
+    q.push_bind(agent_id);
+    if subject.scope_to_tenant(&mut q, "org_id").is_err() {
+        return HttpResponse::Unauthorized().finish();
+    }
+
+    // 3. Execute and respond.
+    match q.build().execute(&state.pool).await {
+        Ok(res) if res.rows_affected() == 1 => HttpResponse::Ok().finish(),
+        Ok(_) => HttpResponse::NotFound().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+```
+
+`scope_to_tenant`:
+
+- Is a **no-op** for `super_admin` (no filter applied — full visibility).
+- Appends `" AND <column> = $N"` with the bound `tenant_id` for any other role.
+- Returns `Err(Unauthorized)` for a non-`super_admin` subject whose JWT carries no `tenant_id` claim. That case is a config error and must fail loudly — never silently scope to "no filter."
+
+For post-fetch checks (read-then-validate flows), use `assert_tenant_match(record_tenant_id)` instead.
+
+## Auto-populating tenant context via `controller: { before: ... }`
+
+If you declare a `before:` controller on a custom endpoint, the runtime runs the same hook pipeline as CRUD endpoints get and stashes the resulting `Context` into the request's actix extensions. Your handler can read `tenant_id`, `user`, `session`, and `response_extras` from there — without manually calling `Subject::from_request`:
+
+```yaml
+# resources/agents.yaml
+endpoints:
+  regenerate_secret:
+    method: POST
+    path: /agents/:id/regenerate_secret
+    auth: [super_admin, admin]
+    controller: { before: prepare_secret_rotation }
+    handler: regenerate_secret
+```
+
+```rust
+// resources/agents.controller.rs — runs before the handler
+pub async fn prepare_secret_rotation(ctx: &mut Context) -> ControllerResult {
+    // ctx.tenant_id is already populated; use it for cross-handler logic.
+    // Stash anything you want the handler to see in ctx.session.
+    ctx.session.insert("rotation_started_at".into(), json!(chrono::Utc::now()));
+    Ok(())
+}
+
+// resources/agents.handlers.rs — runs after the before-controller
+pub async fn regenerate_secret(
+    req: HttpRequest,
+    state: Arc<AppState>,
+    _resource: Arc<ResourceDefinition>,
+    _endpoint: Arc<EndpointSpec>,
+) -> HttpResponse {
+    use shaperail_runtime::handlers::controller::Context;
+    let ctx = req.extensions().get::<Context>().cloned();
+    let tenant = ctx.as_ref().and_then(|c| c.tenant_id.as_deref());
+    // ... use tenant for SQL scoping ...
+    HttpResponse::Ok().finish()
+}
+```
+
+> `after:` controllers are NOT supported on custom endpoints. The custom handler owns the response shape — there is no `data:` envelope for the runtime to merge `response_extras` into. If your logic needs an after-pass, factor it into a helper called from the handler.
+
+## Sharing logic across custom handlers
+
+For endpoints without a before-controller, share logic the normal Rust way: extract a helper function in `resources/<name>.handlers.rs` and call it from each handler. The framework's job is to give you `Subject` and the runtime's `AppState`; your job is to use them.
+
+## What if I want CRUD-style hooks?
+
+Use a CRUD endpoint and the `controller: { before, after }` declaration. The two-phase pipeline plus `Context.session` and `Context.response_extras` cover most "I need to mint a one-time value" cases without writing a custom handler at all. See [Controllers]({{ '/controllers/' | relative_url }}).


### PR DESCRIPTION
## Why

Three changes that should have landed in #77 but missed the merge race — I force-pushed a docs delta to the v0.11.2 branch after the PR was already queued for merge, so the squash picked up the earlier SHA. The merged commit \`993912e\` has only the v0.11.2 code change + \`agent_docs/custom-handlers.md\` body section + initial CLAUDE.md "Release Process" section. It does **not** include the public-facing docs or the CLAUDE.md "Public-mirror requirement" rule.

This is exactly the situation the new CLAUDE.md "Git Workflow" rule warns about ("Never push more commits to a branch with an open PR you intend to merge as-is"). Caught it; this follow-up PR closes the gap.

## What this adds

- **\`docs/custom-handlers.md\`** (new) — public-facing mirror of \`agent_docs/custom-handlers.md\`. Covers all v0.11.x custom-handler features in user-voice form:
  - Reading the request body via \`req.extensions().get::<web::Bytes>()\` (v0.11.2 fix).
  - Authenticating + tenant-scoping queries with \`Subject\`.
  - Auto-populating tenant context via \`controller: { before: ... }\` (v0.11.1 feature).
  - The \`after:\`-controller rejection rationale.
- **\`docs/controllers.md\`** — replaces the stale "controller: is fully rejected on custom endpoints" callout with accurate v0.11.1+ behavior (\`before:\` works, \`after:\` rejected) plus the v0.11.2 body-extraction note. Links into \`docs/custom-handlers.md\` for the full pattern.
- **\`CLAUDE.md\`** "Public-mirror requirement" subsection (under Documentation Rule). Codifies that every \`agent_docs/X.md\` change must have a corresponding \`docs/\` update. Includes a 5-step checklist and a worked-example table mapping recent v0.11.x changes to both doc trees, so future sessions don't repeat this oversight.

## No code changes

Doc-only PR. No version bump — v0.11.2 already published; the docs site rebuilds from \`main\` on every push, so merging this updates shaperail.io to reflect the v0.11.x feature set.

## Quality gate

- ✅ \`cargo build --locked --workspace\` (no code changes; build is a no-op verification)
- ✅ \`cargo fmt --check\`
- ✅ \`cargo clippy --locked --workspace --all-targets -- -D warnings\`
- N/A — version-bump checks; no version change.

## Test plan

- [x] \`docs/custom-handlers.md\` renders cleanly (valid Jekyll front matter, balanced code fences).
- [x] \`docs/controllers.md\` callout no longer claims behavior that was reverted in v0.11.1.
- [x] CLAUDE.md "Public-mirror requirement" subsection is unambiguous and the example table is accurate.
- [ ] Docs site rebuild on merge surfaces the new \`/custom-handlers/\` page in the Guides nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)