### PR TITLE
fix(ci): remove invalid filter_commits field from release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -80,5 +80,4 @@ commit_parsers = [
     { message = "^build", skip = true },
 ]
 
-filter_commits = true
 sort_commits = "newest"


### PR DESCRIPTION
## Summary

The first `Release-plz` run after merging #79 failed with:

```
ERROR invalid config file
Caused by:
    TOML parse error at line 83, column 1
    83 | filter_commits = true
       | ^^^^^^^^^^^^^^
    unknown field \`filter_commits\`, expected one of \`header\`, \`body\`, \`trim\`, \`commit_preprocessors\`, \`postprocessors\`, \`sort_commits\`, \`link_parsers\`, \`commit_parsers\`, \`protect_breaking_commits\`, \`tag_pattern\`
```

`filter_commits` is a git-cliff config field that release-plz's `[changelog]` wrapper does not accept. Dropping it. Unmatched commits will surface in a default group rather than being silently filtered, which is preferable — non-conventional commits stay visible so the maintainer can clean up the release PR before merging.

## Test plan

- [ ] `Release-plz` workflow run on this merge commit succeeds (no TOML parse error)
- [ ] No release PR is opened, since the only commits since `v0.11.2` are `docs:` and `ci:` (both `skip = true` in the parser config) — that is the intended behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)