### PR TITLE
chore(release): skip internal-scoped fixes in release-plz parsers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,8 @@ When unsure where the public version belongs, default to creating a new `docs/<t
   - `feat!: ...` or `BREAKING CHANGE:` in the body → breaking (pre-1.0 minor, post-1.0 major)
   - `perf: ...` / `refactor: ...` → patch bump, listed under **Changed**
   - `chore: ...` / `docs: ...` / `style: ...` / `test: ...` / `ci: ...` / `build: ...` → bookkeeping, **does not trigger a release**
-  - Scope (the `(shaperail-core)` part) is optional but encouraged for crate-specific changes.
+  - **Internal-scoped fixes do not trigger a release.** `fix(ci)`, `fix(release)`, `fix(deps)`, `fix(build)`, `fix(examples)` (and the same scopes with `feat`/`perf`/`refactor`) are skipped by the release-plz parsers. Use these scopes for plumbing changes that have no user-visible effect — e.g. fixing a workflow file, bumping a dev dependency, refreshing an example's lockfile.
+  - Scope (the `(shaperail-core)` part) is optional but encouraged for crate-specific changes. Crate-name scopes (`shaperail-core`, `shaperail-codegen`, `shaperail-runtime`, `shaperail-cli`) on `fix:`/`feat:` commits **do** trigger releases — they signal user-facing crate changes.
   - PR titles MUST follow the same convention — auto-merge squashes the PR title into the merge commit, so the PR title is what release-plz sees.
 - **Never push more commits to a branch with an open PR you intend to merge as-is.** PRs auto-merge as soon as CI is green; follow-up commits frequently land too late and end up stranded on the merged branch. Open a new PR for follow-ups.
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -65,13 +65,28 @@ body = """
 """
 
 commit_parsers = [
+    # Breaking changes (highest priority).
     { message = "^feat!", group = "Breaking" },
     { message = ".*!:", group = "Breaking" },
     { body = ".*BREAKING CHANGE", group = "Breaking" },
+
+    # Internal-only fixes that must NOT trigger a user-facing release.
+    # Anything scoped to ci/release/deps/build/examples is plumbing.
+    # These rules are evaluated first so they win against the generic
+    # `^fix` / `^feat` / `^perf` / `^refactor` rules below.
+    { message = "^(fix|feat|perf|refactor)\\(ci\\)", skip = true },
+    { message = "^(fix|feat|perf|refactor)\\(release\\)", skip = true },
+    { message = "^(fix|feat|perf|refactor)\\(deps\\)", skip = true },
+    { message = "^(fix|feat|perf|refactor)\\(build\\)", skip = true },
+    { message = "^(fix|feat|perf|refactor)\\(examples\\)", skip = true },
+
+    # User-facing changes.
     { message = "^feat", group = "Added" },
     { message = "^fix", group = "Fixed" },
     { message = "^perf", group = "Changed" },
     { message = "^refactor", group = "Changed" },
+
+    # Bookkeeping prefixes — never trigger a release.
     { message = "^chore", skip = true },
     { message = "^docs", skip = true },
     { message = "^style", skip = true },


### PR DESCRIPTION
## Summary

When PR #80 (`fix(ci): remove invalid filter_commits...`) merged, the generic `^fix` parser caught it and release-plz computed a phantom `0.11.3` release for what was purely release-pipeline plumbing. The release PR itself failed to open because of the org-level "Allow GitHub Actions to create or approve pull requests" setting (now flipped on, plus the repo-level toggle), but the spurious version bump exposed a real gap in our parser config.

## Fix

Add explicit skip rules **ahead of** the generic prefix rules so anything scoped to `ci` / `release` / `deps` / `build` / `examples` is treated as bookkeeping regardless of `fix`/`feat`/`perf`/`refactor` prefix:

```toml
{ message = "^(fix|feat|perf|refactor)\\(ci\\)", skip = true },
{ message = "^(fix|feat|perf|refactor)\\(release\\)", skip = true },
{ message = "^(fix|feat|perf|refactor)\\(deps\\)", skip = true },
{ message = "^(fix|feat|perf|refactor)\\(build\\)", skip = true },
{ message = "^(fix|feat|perf|refactor)\\(examples\\)", skip = true },
```

Crate-name scopes (`fix(shaperail-core)`, `feat(shaperail-runtime)`, etc.) are unaffected — those continue to trigger releases because they signal user-facing crate changes.

## CLAUDE.md update

Documents the scoped-skip convention under the Conventional Commits section so future Claude sessions and contributors use the right scope:

- `fix(ci)` / `fix(release)` / `fix(deps)` / `fix(build)` / `fix(examples)` → plumbing, skipped
- `fix(shaperail-core)` / `fix(shaperail-runtime)` / etc. → user-facing, releases

## Why this PR doesn't trigger a release

`chore(release):` prefix → `^chore` parser → `skip = true` (already in place). When release-plz runs after merge, the entire commit range since `v0.11.2` will be skipped:

| Commit | Outcome |
|---|---|
| `docs: public mirror...` | skip (`^docs`) |
| `ci: replace custom release pipeline...` | skip (`^ci`) |
| `fix(ci): remove invalid filter_commits...` | skip (new `fix(ci)` rule) |
| `chore(examples): update incident-platform deps...` | skip (`^chore`) |
| `chore(deps): bump wat from 1.247.0 to 1.248.0` | skip (`^chore`) |
| `chore(release): skip internal-scoped fixes...` (this PR) | skip (`^chore`) |

Expected result: `Release-plz` workflow run completes successfully, opens **no** release PR.

## Test plan

- [ ] CI green
- [ ] After merge, `Release-plz` workflow run succeeds (no 403, no parse errors)
- [ ] No release PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)