### PR TITLE
chore(release): document v0.11.3 contents and harden release-plz config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-05-02
+
+> **Note on version label.** Both bullet points under **Breaking** below would normally warrant a minor bump under this project's pre-1.0 semver convention (breaking changes go to `0.x+1.0`). They shipped under `0.11.3` due to a release-PR race in the new release-plz pipeline: an empty release PR was created during the pipeline cutover and was merged in parallel with the `feat!:` PR, so the version computation never saw the breaking-change commits. The published `0.11.3` artifacts on crates.io contain the changes described here regardless of the version label. The next user-visible change will trigger a clean `0.12.0`.
+
 ### Breaking
 
 - **`handler:` on convention action keys is now a hard validation error.** Declaring `handler: <fn>` on `list` / `get` / `update` / `create` / `delete` was previously silently dropped at codegen time — `collect_custom_handlers` filtered the entry out, the function was never registered, and the endpoint served the standard CRUD response. The new validator rule (`shaperail-codegen/src/validator.rs::validate_handler_only_on_custom`) rejects this with a clear error and a workaround that renames the endpoint key to a non-convention action (e.g. `post_<resource>`) with explicit `method:` / `path:`. To customize standard CRUD without replacing the runtime path, use `controller: { before: ... }` / `controller: { after: ... }` on the convention key. Closes Issue F.
@@ -285,3 +289,4 @@ In practice, the v0.11.0 versions of both functions were broken-by-design for th
 [0.11.0]: https://github.com/shaperail/shaperail/releases/tag/v0.11.0
 [0.11.1]: https://github.com/shaperail/shaperail/releases/tag/v0.11.1
 [0.11.2]: https://github.com/shaperail/shaperail/releases/tag/v0.11.2
+[0.11.3]: https://github.com/shaperail/shaperail/releases/tag/shaperail-cli-v0.11.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,8 @@ A merge consisting only of bookkeeping commits does not open a release PR. That 
 - The generated CHANGELOG section follows Keep-a-Changelog with `Breaking` / `Added` / `Changed` / `Fixed` subsections. Subsections with no entries are skipped.
 - Hand-edits to the CHANGELOG inside the release PR branch are preserved — release-plz only regenerates if commits are added.
 - Once a release is published, **never edit its CHANGELOG section** — it is frozen historical record.
+- **Never merge a release PR with an empty changelog body.** If release-plz opens a `chore(release): X.Y.Z` PR whose body has no real entries (just `<details>...</details>` with blank lines), close it instead of merging — merging it ships an empty release that mislabels future user-facing changes. The `release_commits` regex in `release-plz.toml` is the primary guard against this, but treat the empty-body case as a final manual check.
+- **If two release PRs are open at once, close the older one.** This can happen during a pipeline transition or when a `feat!:` lands while a patch-only release PR is already open. Keep only the PR with the correct target version; release-plz will re-sync on the next push.
 
 **RUSTSEC advisories** must be either upgraded out (`cargo update -p <crate> --precise <version>`) or ignored in `.cargo/audit.toml` with a comment explaining the upstream block. `cargo audit` runs in `ci.yml` on every PR.
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,6 +12,16 @@ dependencies_update = true
 release_always = false
 pr_name = "chore(release): {{ version }}"
 
+# Only commits matching this regex count toward "is there anything to release?"
+# Tightens the rule beyond commit_parsers below: even if a `chore(release):`
+# parser misbehaves and the changelog is empty, release-plz won't open a
+# release PR unless at least one user-facing commit exists in the range.
+#
+# Match feat/fix/perf/refactor either unscoped or with a crate scope. The
+# internal scopes (ci/release/deps/build/examples) are deliberately excluded
+# so internal-pipeline fixes never trigger a release on their own.
+release_commits = "^(feat|fix|perf|refactor)(\\(shaperail-(core|codegen|runtime|cli)\\))?[!]?:"
+
 # Use the existing CHANGELOG.md format.
 changelog_update = true
 


### PR DESCRIPTION
## What this PR does

Cleanup after the v0.11.3 release race. v0.11.3 is already published on crates.io with the right code (Issue F + G fixes from #84) but the wrong version label and an empty changelog. This PR fixes the metadata and prevents recurrence — no shipped behavior changes.

## Three corrections

### 1. `CHANGELOG.md`

Move the `[Unreleased]` Breaking / Changed / Removed entries into a `[0.11.3] - 2026-05-02` section. Add a "Note on version label" preamble explaining the race so anyone browsing the changelog understands why two breaking changes shipped under a patch version.

### 2. `release-plz.toml`

Add a `release_commits` regex:

```toml
release_commits = "^(feat|fix|perf|refactor)(\\(shaperail-(core|codegen|runtime|cli)\\))?[!]?:"
```

Only commits matching this regex count toward "is there anything to release?" Internal-scoped commits (`fix(ci)`, `chore(deps)`, etc.) cannot trigger a release PR even if a parser misbehaves. This is the primary guard against another empty-changelog release PR — the empty `chore(release): 0.11.3` PR that caused this mess would never have opened with this in place.

The regex matches:
- `feat: ...` (unscoped)
- `fix(shaperail-core): ...` (crate scope)
- `feat!: ...` / `fix(shaperail-runtime)!: ...` (breaking)
- `perf: ...`, `refactor: ...`

It does NOT match:
- `chore(release): ...` / `chore(deps): ...` / `chore: ...`
- `fix(ci): ...` / `feat(deps): ...` / `perf(build): ...` / etc.
- `docs: ...`, `style: ...`, `test: ...`, `ci: ...`, `build: ...`

### 3. `CLAUDE.md`

Two reviewer guardrails added to the Release Process section:

- **Never merge a release PR with an empty changelog body.** If release-plz opens a `chore(release): X.Y.Z` PR whose body has no real entries, close it instead. Merging an empty release PR ships nothing-by-name and mislabels the next user-facing change.
- **If two release PRs are open at once, close the older one** and let release-plz re-sync on the next push.

## Also done outside this PR (no commit needed)

Updated GitHub Release notes for v0.11.3 via `gh release edit`:

- `shaperail-cli-v0.11.3` (the "Latest" tag) now has the full release notes.
- The three sibling crate release pages (`shaperail-core-v0.11.3`, `shaperail-codegen-v0.11.3`, `shaperail-runtime-v0.11.3`) point to the cli release page.

## Conventional commit

`chore(release):` — bookkeeping. `^chore` parser skips this from the next changelog. `release_commits` regex doesn't match. No release PR will open from this merge.

## Test plan

- [ ] CI green
- [ ] After merge, `Release-plz` workflow run succeeds and opens **no** release PR (next release waits for a real `feat:` / `fix:` / `feat!:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)