### PR TITLE
ci(release): add workflow_dispatch to release-plz.yml

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,6 +23,10 @@ name: Release-plz
 on:
   push:
     branches: [main]
+  # Manual trigger for re-runs after a transient failure (e.g. release-plz's
+  # action wrapper swallowed a 422 from the GitHub API) without needing to
+  # push an empty commit. No inputs.
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Why

Yesterday's `0.12.0` release PR didn't open. The `release-plz/action@v0.5` wrapper script swallowed a 422 from the GitHub API:

> `release-plz release-pr failed with HTTP 422; continuing with no PRs created.`

The most plausible cause was three stale release-plz branches left over from earlier runs:

- `release-plz-2026-05-02T16-57-31Z`
- `release-plz-2026-05-02T17-09-13Z`
- `release-plz-2026-05-02T17-31-44Z` (the closed PR #85's branch)

I deleted all three via the GitHub API. To re-trigger release-plz now that the branches are gone, the workflow needs either a push to main or a `workflow_dispatch` button — and we don't have the latter.

## Fix

Add `workflow_dispatch: {}` to `.github/workflows/release-plz.yml`. No inputs.

## Bonus

Merging this PR is itself a push to main, which will re-trigger release-plz on the freshly cleaned-up state. If the 422 was caused by the stale branches (most likely), this merge produces the missing `chore(release): 0.12.0` PR.

If the 422 had a different cause and the merge still fails, the new "Run workflow" button on the Actions tab gives us a one-click retry without needing to push an empty commit.

## Conventional commit

`ci(release):` prefix → skipped by parsers and `release_commits` regex. This commit alone never opens a release PR; it only re-triggers the workflow which then sees the existing `feat!:` from PR #87 and computes 0.12.0.

## Test plan

- [ ] CI green
- [ ] After merge, `Release-plz` workflow run succeeds and opens `chore(release): 0.12.0`
- [ ] If it doesn't, the "Run workflow" button is now available as a fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)