### PR TITLE
fix(ci): add version_group=workspace to release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -34,23 +34,36 @@ publish = true
 publish_features = []
 allow_dirty = false
 
-# Per-crate overrides: explicit publish=true and the dependency-driven
-# publish order is computed automatically by cargo.
+# Per-crate overrides. All four crates share `workspace.package.version`
+# (each declares `version.workspace = true`) and must release together at
+# one version. `version_group = "workspace"` tells release-plz to assign
+# the same version — the highest among the next versions of the grouped
+# packages — to every crate in the group, instead of computing per-crate
+# versions independently. Without this, a `feat!:` that touches only
+# shaperail-runtime bumps just that crate, leaving codegen/core stuck and
+# causing `cargo update` to fail with "candidate versions found which
+# didn't match: 0.12.0" because internal `version = "0.11.3"` pins on the
+# unbumped crates won't satisfy `^0.11.3` against a 0.12.0 path-resolved
+# dep.
 [[package]]
 name = "shaperail-core"
 publish = true
+version_group = "workspace"
 
 [[package]]
 name = "shaperail-codegen"
 publish = true
+version_group = "workspace"
 
 [[package]]
 name = "shaperail-runtime"
 publish = true
+version_group = "workspace"
 
 [[package]]
 name = "shaperail-cli"
 publish = true
+version_group = "workspace"
 
 # Conventional-commit changelog grouping. Headings and order match the
 # existing CHANGELOG.md sections (Breaking, Added, Changed, Fixed).


### PR DESCRIPTION
## What broke

PR #87's `feat!:` (Issue H fix) failed to produce a release PR. The release-plz workflow run errored with:

\`\`\`
ERROR failed to update packages
Caused by:
    cargo update failed.
    error: failed to select a version for the requirement \`shaperail-core = "^0.11.3"\`
    candidate versions found which didn't match: 0.12.0
    required by package \`shaperail-codegen v0.12.0\`
\`\`\`

## Why

release-plz computed per-crate versions **independently**:

| Crate | Computed next version | Why |
|---|---|---|
| `shaperail-core` | 0.11.3 (no bump) | no commit matched `release_commits` |
| `shaperail-codegen` | 0.11.3 (no bump) | no commit matched `release_commits` |
| `shaperail-runtime` | **0.12.0** | the `feat!:` commit was in this crate |
| `shaperail-cli` | 0.11.4 | dep on runtime changed |

But all four crates inherit `version.workspace = true`, so they must share one version. release-plz tried to apply the per-crate computation anyway: when shaperail-codegen got bumped to 0.12.0, its declared dep `shaperail-core = "^0.11.3"` no longer matched the path-resolved core (which was also 0.12.0). cargo update failed.

## Fix

Add `version_group = "workspace"` to each `[[package]]` entry:

\`\`\`toml
[[package]]
name = "shaperail-core"
publish = true
version_group = "workspace"
# ...same for shaperail-codegen, shaperail-runtime, shaperail-cli
\`\`\`

Per [release-plz docs](https://release-plz.dev/docs/config): "release-plz will assign the same version to them (the highest among the next versions of the packages)."

So all four crates will get **0.12.0** in lockstep, internal dep pins will be rewritten consistently, and one coherent release PR opens for the whole workspace.

## Conventional commit

`fix(ci):` prefix → skipped by `release_commits` regex (the new one we just installed). This commit alone never triggers a release PR.

## What happens after merge

1. Push to main triggers release-plz with the corrected config.
2. release-plz sees PR #87's `feat!:` still in range since `shaperail-cli-v0.11.3`, computes 0.12.0 for the workspace group, and opens `chore(release): 0.12.0`.
3. You review and merge → crates publish to crates.io as 0.12.0, GitHub Release with binaries follows.

If for any reason it still doesn't open, the `workflow_dispatch` button (added in PR #88) is now available for one-click retries.

## Test plan

- [ ] CI green
- [ ] After merge, release-plz workflow completes successfully and opens `chore(release): 0.12.0`
- [ ] No "failed to select a version" errors in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)