### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-03
+
 ### Breaking
 
 - **List endpoints reject bracket-notation filter params for undeclared fields.** `validate_filter_param_form` in `shaperail-runtime/src/handlers/params.rs` was extended: in addition to the v0.11.3 `INVALID_FILTER_FORM` rejection of bare-field params that match a declared filter, the runtime now also returns **422** with code `UNDECLARED_FILTER` when a request sends `?filter[<field>]=<value>` and `<field>` is not in the endpoint's `filters:` list (or the endpoint declares no filters at all). The error message names the available filters when there are any, or notes that the endpoint declares none. Multiple offending keys accumulate into a single 422 response. Closes Issue H.
+
+> **Release note:** This release was version-bumped manually rather than via release-plz auto-versioning. The auto-version path failed because release-plz computes per-crate versions independently from commit file paths, but our workspace shares `workspace.package.version` — when only `shaperail-runtime` had relevant commits, `version_group = "workspace"` lifted the other crates to 0.12.0 but `dependencies_update` did not rewrite the unbumped crates' internal `shaperail-core = "^0.11.3"` pins to `"0.12.0"`, so `cargo update` failed with "candidate versions found which didn't match: 0.12.0". A long-term fix using `[workspace.dependencies]` inheritance is tracked as a follow-up.
 
 ## [0.11.3] - 2026-05-02
 
@@ -294,3 +298,4 @@ In practice, the v0.11.0 versions of both functions were broken-by-design for th
 [0.11.1]: https://github.com/shaperail/shaperail/releases/tag/v0.11.1
 [0.11.2]: https://github.com/shaperail/shaperail/releases/tag/v0.11.2
 [0.11.3]: https://github.com/shaperail/shaperail/releases/tag/shaperail-cli-v0.11.3
+[0.12.0]: https://github.com/shaperail/shaperail/releases/tag/v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-cli"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-codegen"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "indexmap",
  "insta",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-core"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-runtime"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "actix-multipart",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shaperail-core", "shaperail-codegen", "shaperail-runtime", "shaperai
 resolver = "2"
 
 [workspace.package]
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/shaperail-cli/Cargo.toml
+++ b/shaperail-cli/Cargo.toml
@@ -15,9 +15,9 @@ name = "shaperail"
 path = "src/main.rs"
 
 [dependencies]
-shaperail-codegen = { version = "0.11.3", path = "../shaperail-codegen" }
-shaperail-core = { version = "0.11.3", path = "../shaperail-core" }
-shaperail-runtime = { version = "0.11.3", path = "../shaperail-runtime" }
+shaperail-codegen = { version = "0.12.0", path = "../shaperail-codegen" }
+shaperail-core = { version = "0.12.0", path = "../shaperail-core" }
+shaperail-runtime = { version = "0.12.0", path = "../shaperail-runtime" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/shaperail-codegen/Cargo.toml
+++ b/shaperail-codegen/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-shaperail-core = { version = "0.11.3", path = "../shaperail-core" }
+shaperail-core = { version = "0.12.0", path = "../shaperail-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/shaperail-runtime/Cargo.toml
+++ b/shaperail-runtime/Cargo.toml
@@ -20,7 +20,7 @@ observability-otlp = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:ope
 test-support = []
 
 [dependencies]
-shaperail-core = { version = "0.11.3", path = "../shaperail-core" }
+shaperail-core = { version = "0.12.0", path = "../shaperail-core" }
 actix-web = { workspace = true }
 actix-ws = { workspace = true }
 actix-multipart = { workspace = true }


### PR DESCRIPTION
## Why this is a manual bump

PR #87's `feat!:` (Issue H — UNDECLARED_FILTER) merged successfully but release-plz's auto-versioning could not produce a release PR. After three workflow runs and two config tweaks (PR #88 added `workflow_dispatch`, PR #89 added `version_group = "workspace"`), the underlying issue persisted:

- release-plz computes per-crate next versions from commit **file paths**.
- PR #87's commit only touched `shaperail-runtime/`, so only `runtime` saw a `feat!:` and bumped to 0.12.0.
- `version_group = "workspace"` correctly lifted core/codegen/cli to 0.12.0 too.
- BUT `dependencies_update` did NOT rewrite the unbumped crates' internal `shaperail-core = "^0.11.3"` pins to `"0.12.0"`. release-plz appears to skip the dep-rewrite pass for crates that didn't have their own commits.
- Result: `cargo update` failed with `failed to select a version for shaperail-core = "^0.11.3"; candidate versions found which didn't match: 0.12.0`.

## What this PR does

Hand-edits all six places to 0.12.0:

- `Cargo.toml` `[workspace.package] version`
- `shaperail-codegen/Cargo.toml` — `shaperail-core` pin
- `shaperail-runtime/Cargo.toml` — `shaperail-core` pin
- `shaperail-cli/Cargo.toml` — three internal pins (`shaperail-codegen`, `shaperail-core`, `shaperail-runtime`)
- `Cargo.lock` — refreshed via `cargo check`
- `CHANGELOG.md` — `[Unreleased]` Breaking moved to `[0.12.0] - 2026-05-03` with a "Release note" explaining the manual bump for future archaeology.

## What ships in 0.12.0

- **Issue H** — `UNDECLARED_FILTER` rejection of bracket-notation filter params for fields not in the endpoint's declared `filters:`. Returns 422 with a message naming available filters. (PR #87 already merged to main.)

The Issue F + G fixes already shipped in v0.11.3 (per the v0.11.3 release notes); they're not re-listed here.

## What happens after merge

1. Push to main with workspace version `0.12.0` ahead of latest tag (`shaperail-cli-v0.11.3`).
2. release-plz's `release` job sees the version is ahead, publishes all four crates to crates.io as 0.12.0, tags `v0.12.0`, and creates the GitHub Release.
3. release-plz's `release-pr` job runs, sees no further bump needed (version matches what release just tagged), and opens no new release PR.
4. `release-binaries.yml` fires on `release: published` and uploads 5 platform archives.

## Verification

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `Cargo.lock` updated (all four shaperail crates show `version = "0.12.0"`)

## Conventional commit

`chore(release):` prefix → skipped by parsers and `release_commits` regex. This commit alone won't open another release PR.

## Follow-up (separate PR)

Refactor internal deps to use `[workspace.dependencies]` inheritance:

\`\`\`toml
# Cargo.toml
[workspace.dependencies]
shaperail-core = { version = "0.12.0", path = "shaperail-core" }
\`\`\`

\`\`\`toml
# shaperail-codegen/Cargo.toml
[dependencies]
shaperail-core.workspace = true
\`\`\`

That sidesteps release-plz's per-crate pin-rewrite limitation entirely — there's exactly one place to update internal deps, and release-plz handles workspace deps cleanly.

## Test plan

- [ ] CI green
- [ ] After merge, release-plz `release` job publishes 0.12.0 to crates.io
- [ ] `gh release view v0.12.0` shows the tag
- [ ] `release-binaries.yml` uploads 5 archives within ~15 minutes
- [ ] `cargo install shaperail-cli@0.12.0` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)