### PR TITLE
fix(ci): unblock 0.12.0 publish + inherit internal deps via workspace.dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,3 +257,7 @@ cargo install shaperail-cli@X.Y.Z                        # crates.io has it
 Cross-platform binaries take ~15 minutes (Windows MSVC is the long pole). crates.io publish completes earlier, so `cargo install` works before the GitHub Release page shows binaries.
 
 Configuration lives in `release-plz.toml` at the repo root. Required GitHub secret: `CARGO_REGISTRY_TOKEN` with publish scope for all four crates.
+
+**Internal crate version pins live ONLY in `[workspace.dependencies]` in the root `Cargo.toml`.** Each consumer's `[dependencies]` section uses `<crate>.workspace = true` to inherit. Do not add explicit `version = "..."` pins on `shaperail-*` deps in any consumer crate — release-plz's per-crate analysis can leave such pins stale when `version_group = "workspace"` lifts a crate that had no commits of its own, causing `cargo update` to fail with "candidate versions found which didn't match: X.Y.Z". One-place inheritance sidesteps this.
+
+**Do NOT set `release_always = false` in `release-plz.toml`.** It blocks the publish step on commits that weren't merged through a release-plz-generated PR (e.g. manual version bumps), so a stuck release becomes "skipping release: current commit is not from a release PR". Empty release PRs are already prevented by the `release_commits` regex; we don't need this flag.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,17 @@ keywords = ["web", "api", "framework", "code-generation"]
 categories = ["web-programming::http-server", "development-tools"]
 
 [workspace.dependencies]
+# Internal crates — pinned in one place so release-plz only needs to
+# update workspace.package.version + these four lines on a release. Each
+# consumer crate inherits via `<name>.workspace = true` in its
+# [dependencies] section. Without this, internal version pins live in
+# every consumer's Cargo.toml and release-plz's per-crate analysis can
+# leave some pins stale when a release bumps the workspace via
+# version_group but the consumer crate had no commits of its own.
+shaperail-core = { version = "0.12.0", path = "shaperail-core" }
+shaperail-codegen = { version = "0.12.0", path = "shaperail-codegen" }
+shaperail-runtime = { version = "0.12.0", path = "shaperail-runtime" }
+
 # Async
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,8 +9,23 @@
 dependencies_update = true
 
 # One release PR for the whole workspace, not one per crate.
-release_always = false
 pr_name = "chore(release): {{ version }}"
+
+# `release_always = true` (the default) tells release-plz to publish on
+# every push to main when the workspace version is ahead of the latest
+# tag, regardless of whether the merge was from a release-plz-generated
+# PR. This is the right setting for our pipeline because:
+#
+# - The `release_commits` regex below already gates whether a release PR
+#   opens at all, so we won't get spurious empty release PRs from chore:
+#   commits.
+# - Manual version bumps (e.g. when auto-versioning hits a workspace
+#   shared-version edge case) still publish through the normal flow.
+#
+# An earlier iteration set this to false to prevent empty release PRs,
+# but that also blocked publishing manually-bumped versions with the log
+# line "skipping release: current commit is not from a release PR".
+release_always = true
 
 # Only commits matching this regex count toward "is there anything to release?"
 # Tightens the rule beyond commit_parsers below: even if a `chore(release):`

--- a/shaperail-cli/Cargo.toml
+++ b/shaperail-cli/Cargo.toml
@@ -15,9 +15,9 @@ name = "shaperail"
 path = "src/main.rs"
 
 [dependencies]
-shaperail-codegen = { version = "0.12.0", path = "../shaperail-codegen" }
-shaperail-core = { version = "0.12.0", path = "../shaperail-core" }
-shaperail-runtime = { version = "0.12.0", path = "../shaperail-runtime" }
+shaperail-codegen = { workspace = true }
+shaperail-core = { workspace = true }
+shaperail-runtime = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/shaperail-codegen/Cargo.toml
+++ b/shaperail-codegen/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-shaperail-core = { version = "0.12.0", path = "../shaperail-core" }
+shaperail-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/shaperail-runtime/Cargo.toml
+++ b/shaperail-runtime/Cargo.toml
@@ -20,7 +20,7 @@ observability-otlp = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:ope
 test-support = []
 
 [dependencies]
-shaperail-core = { version = "0.12.0", path = "../shaperail-core" }
+shaperail-core = { workspace = true }
 actix-web = { workspace = true }
 actix-ws = { workspace = true }
 actix-multipart = { workspace = true }


### PR DESCRIPTION
## What this PR does

Bundles two changes that together unblock 0.12.0 today **and** make future releases truly automatic:

1. **`release-plz.toml`** — flip `release_always = false` → `release_always = true`. Allows the publish step to run when the merge wasn't from a release-plz-generated PR (e.g. our manual bump in #90).
2. **Workspace deps refactor** — move all four `shaperail-*` internal version pins from each consumer's `[dependencies]` to the root `Cargo.toml`'s `[workspace.dependencies]`. Each consumer inherits via `shaperail-core.workspace = true` (etc.).

Both changes target the same root cause that's blocked the auto-pipeline so far.

## Why this fixes the auto-pipeline

release-plz computes per-crate next versions from commit file paths. A `feat!:` that only touches `shaperail-runtime/` bumps just runtime. `version_group = "workspace"` correctly lifts the other crates to the same version, but `dependencies_update` then skips rewriting the explicit `shaperail-core = "^0.11.3"` pins on the lifted crates. cargo update fails because workspace says 0.12.0 but the dep declarations still say `^0.11.3`.

With `[workspace.dependencies]` inheritance there's **one** place to update the internal version pins. Bumping the workspace updates everything atomically.

## Files changed

- `Cargo.toml` — `[workspace.dependencies]` gets four new entries for `shaperail-core`, `shaperail-codegen`, `shaperail-runtime` (paths relative to root).
- `shaperail-codegen/Cargo.toml` — `shaperail-core = { workspace = true }`
- `shaperail-runtime/Cargo.toml` — `shaperail-core = { workspace = true }`
- `shaperail-cli/Cargo.toml` — three internal deps switched to `.workspace = true`
- `release-plz.toml` — `release_always = true` with comment explaining why
- `CLAUDE.md` — convention note: never add explicit version pins on internal deps in consumer crates; never set `release_always = false`

## Verification

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## What happens after merge

1. Push to main carries workspace version `0.12.0`, still ahead of tag `shaperail-cli-v0.11.3`.
2. release-plz's `release` job no longer skips (because `release_always = true`). It publishes all four crates to crates.io as 0.12.0, tags `v0.12.0`, creates the GitHub Release.
3. `release-binaries.yml` fires on `release: published` and uploads 5 platform archives.

Future breaking-change PRs that touch only one crate will then auto-version cleanly because `[workspace.dependencies]` doesn't have the per-crate pin-rewrite limitation.

## Conventional commit

The merge commit (squashed from this PR) will be `fix(ci):` — skipped by `release_commits` regex, won't open a new release PR. release-plz's `release` job runs regardless and proceeds to publish since version > tag.

## Test plan

- [ ] CI green
- [ ] After merge, `gh release view v0.12.0` shows the tag
- [ ] `cargo install shaperail-cli@0.12.0` succeeds
- [ ] `release-binaries.yml` uploads 5 archives within ~15 minutes
- [ ] Future single-crate `feat!:` PRs auto-bump cleanly without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)