### PR TITLE
feat!: v0.13.0 — integer defaults to 64-bit; AuthenticatedUser uses sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+- **`integer` field type is now 64-bit.** `type: integer` maps to Postgres `BIGINT`, Rust `i64`, OpenAPI `format: int64`, Protobuf `int64`. The separate `bigint` field type has been removed — use `integer` everywhere. Resources still declaring `type: bigint` fail validation with `E_BIGINT_REMOVED` and a migration hint. Motivation: `i32::MAX` cents is ~$21M USD, far below practical money limits, and the framework can't tell which integer columns are money-shaped, so the safer default wins. Closes the integer-money codegen footgun reported on GitHub.
+- **`AuthenticatedUser.id` renamed to `AuthenticatedUser.sub`; `Subject.id` renamed to `Subject.sub`.** The field holds the JWT `sub` claim, which is opaque per RFC 7519 and has no defined relationship to any database row. The previous name read like a `users.id` and invited custom handlers to bind it to foreign-key columns, which silently fails for `super_admin` (whose `sub` is a platform identity, not a `users` row). Migration: rename `user.id` → `user.sub` at every call site. Doc comments now explicitly state that `sub` MUST NOT be bound to FK columns without verifying. Closes the super-admin FK-violation report on GitHub.
+
 ### Added
 - **Element-level constraints on array `items:`.** `items:` now accepts a constraint map (`{ type: string, min: 3, max: 3 }`, `{ type: enum, values: [...] }`, `{ type: uuid, ref: organizations.id }`) in addition to the bare-name shorthand. Element validation runs per element with `<field>[<index>]` error paths; `items.ref` performs a runtime existence check on Postgres.
 

--- a/agent_docs/auth-claims.md
+++ b/agent_docs/auth-claims.md
@@ -4,7 +4,7 @@ Shaperail mints HS256 JWTs with the following claim shape:
 
 | Claim        | Required for | Notes |
 |--------------|--------------|-------|
-| `sub`        | always       | User ID (UUID). |
+| `sub`        | always       | Opaque subject identifier per RFC 7519. See "JWT `sub` is opaque" below. |
 | `role`       | always       | Must match a role in any endpoint's `auth:` list (or be `super_admin` for unrestricted access). |
 | `iat` / `exp`| always       | Unix seconds. |
 | `token_type` | always       | `"access"` for protected requests; `"refresh"` is valid only against the refresh endpoint. |
@@ -50,3 +50,36 @@ The 401 response body is unchanged across reasons; the audit signal is in the lo
 For a non-`super_admin` subject hitting a resource that declares `tenant_key:`, the runtime requires `tenant_id` to be present and uses it as the canonical tenant filter. CRUD endpoints inject the filter automatically; custom handlers must extract `Subject` and apply it explicitly (see `agent_docs/custom-handlers.md` once Batch 1 lands).
 
 A `super_admin` subject is exempt from tenant filtering — the runtime treats their `tenant_id` claim (if any) as advisory and applies no implicit `WHERE tenant_id = ...` filter.
+
+## JWT `sub` is opaque
+
+`AuthenticatedUser.sub` and `Subject.sub` (renamed from `.id` in v0.13.0) hold the unprocessed JWT `sub` claim. Per RFC 7519, `sub` is an opaque identifier — it has no defined relationship to any database row. Custom handlers MUST NOT bind it directly to foreign-key columns without first verifying the row exists.
+
+For tenant roles (e.g. `admin`, `member`, `viewer`) `sub` is conventionally the `users.id` UUID, so binding works. For platform-level roles like `super_admin`, `sub` is a routable identity that does NOT correspond to a `users` row, and binding it to `users(id)`-referencing columns triggers a foreign-key constraint violation at insert/update time.
+
+Pattern for handlers that need to record "who decided this":
+
+```rust
+let auth = try_extract_auth(&req);
+
+// WRONG — silently fails for super_admin, whose sub does not exist in `users`.
+let reviewer: Option<Uuid> = auth.as_ref().and_then(|u| Uuid::parse_str(&u.sub).ok());
+
+// RIGHT — narrow the FK assignment to roles whose sub is a users.id.
+let reviewer: Option<Uuid> = match auth.as_ref() {
+    Some(u) if u.role == "super_admin" => None,
+    Some(u) => Uuid::parse_str(&u.sub).ok(),
+    None => None,
+};
+```
+
+If your application has its own platform-vs-tenant role boundary, encode that boundary explicitly in your handler — the framework deliberately does not infer it.
+
+## Migrating from v0.12
+
+`AuthenticatedUser.id` was renamed to `AuthenticatedUser.sub`, and `Subject.id` to `Subject.sub`, to match RFC 7519 vocabulary. Mechanical rename at every call site:
+
+```diff
+- let reviewer = Uuid::parse_str(&auth.id).ok();
++ let reviewer = Uuid::parse_str(&auth.sub).ok();
+```

--- a/agent_docs/plans/2026-05-03-v0.13.0-integer-bigint-and-auth-sub.md
+++ b/agent_docs/plans/2026-05-03-v0.13.0-integer-bigint-and-auth-sub.md
@@ -1,0 +1,759 @@
+# v0.13.0 — `integer` defaults to BIGINT + `AuthenticatedUser.sub` rename
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve two GitHub-reported v0.12.0 footguns: (a) `integer` codegens to Postgres `INTEGER` capping money-shaped values at i32::MAX, and (b) `AuthenticatedUser.id` is misnamed — it holds the JWT `sub` claim, which is opaque per RFC 7519 and may not map to a `users.id` row (super_admin FK violations).
+
+**Architecture:**
+- **Issue 1**: collapse to ONE integer type. `FieldType::Integer` becomes 64-bit (`i64` / `BIGINT`). `FieldType::Bigint` is removed from the enum. The YAML validator emits a friendly error if `bigint` appears, telling authors to use `integer`. Every internal `match FieldType { Integer | Bigint }` collapses to `Integer`.
+- **Issue 2**: rename `AuthenticatedUser.id` → `AuthenticatedUser.sub` and `Subject.id` → `Subject.sub`. Doc comments state explicitly that `sub` is opaque and MUST NOT be bound to FK columns without first verifying it maps to a row. No new typed `user_row_id` field — that semantics belongs to apps, not the framework.
+- Both shipped together as a single `feat!:` release for v0.13.0. Conventional-commit-tagged so release-plz picks the breaking-minor bump.
+
+**Tech Stack:** Rust 1.85, sqlx 0.8 (Postgres), actix-web 4, serde_yaml. Touches `shaperail-core`, `shaperail-codegen`, `shaperail-runtime`, plus example resource YAMLs and docs.
+
+---
+
+## File Map
+
+**shaperail-core**
+- Modify: `shaperail-core/src/field_type.rs` — drop `Bigint` variant, change `Integer`'s Rust type to `i64`.
+
+**shaperail-codegen** (Issue 1 fanout)
+- Modify: `shaperail-codegen/src/validator.rs` — remove `Bigint` from accepted constraint sets; add explicit error when `type: bigint` is encountered.
+- Modify: `shaperail-codegen/src/rust.rs` — collapse `Integer | Bigint` arms; change generated parser to `i64`; change emitted SQL string from `"integer"` to `"bigint"`.
+- Modify: `shaperail-codegen/src/openapi.rs` — drop `Bigint` arm; emit `format: int64` for `Integer`.
+- Modify: `shaperail-codegen/src/typescript.rs` — keep `number` mapping; just drop the `bigint` arm.
+- Modify: `shaperail-codegen/src/json_schema.rs` — remove `bigint` from the type enum.
+- Modify: `shaperail-codegen/src/proto.rs` — change `Integer` to emit `int64`; drop `Bigint` arm.
+
+**shaperail-runtime** (Issue 1 fanout)
+- Modify: `shaperail-runtime/src/db/query.rs` — change all `Integer => "INTEGER"` to `Integer => "BIGINT"`; drop `Bigint` arms; change `BindValue::Int(... as i32)` to `BindValue::Bigint(...)` for the `Integer` arm.
+- Modify: `shaperail-runtime/src/grpc/codec.rs` — drop `Bigint` arms.
+- Modify: `shaperail-runtime/src/db/mongo.rs` — keep `Integer => "long"` and `Bson::Int64` (was Int32); drop `Bigint`.
+- Modify: `shaperail-runtime/src/graphql/schema.rs` — drop `Bigint` arm.
+- Modify: `shaperail-runtime/src/handlers/validate.rs` — collapse `Integer | Bigint` arms.
+- Modify: `shaperail-runtime/src/handlers/crud.rs` — drop the `Bigint` arm.
+
+**shaperail-runtime** (Issue 2)
+- Modify: `shaperail-runtime/src/auth/extractor.rs` — rename `id` field to `sub`. Update doctest, FromRequest impl, both extract paths, and unit tests.
+- Modify: `shaperail-runtime/src/auth/subject.rs` — rename `Subject.id` to `Subject.sub`. Update `From<&AuthenticatedUser>` impl and tests.
+- Modify: `shaperail-runtime/src/auth/rbac.rs` — update `user.id` → `user.sub` references and test fixtures.
+- Modify: `shaperail-runtime/src/auth/api_key.rs` — update test fixture.
+- Modify: `shaperail-runtime/src/grpc/server.rs` — change `id: claims.sub` to `sub: claims.sub`; update test.
+- Modify: `shaperail-runtime/src/grpc/interceptor.rs` — same.
+- Modify: `shaperail-runtime/tests/handler_tests.rs` — update all fixtures and assertions.
+
+**Example YAMLs** (Issue 1 — `bigint` removed)
+- Modify: `examples/enterprise-saas/resources/invoices.yaml` — `bigint` → `integer` (3 occurrences).
+- Modify: `examples/enterprise-saas/resources/customers.yaml` — 1 occurrence.
+- Modify: `examples/enterprise-saas/resources/payments.yaml` — 1 occurrence.
+- Modify: `examples/incident-platform/resources/attachments.yaml` — 1 occurrence.
+
+**Docs**
+- Modify: `agent_docs/resource-format.md` — drop `bigint` row from field-type table; document that `integer` is 64-bit.
+- Modify: `agent_docs/auth-claims.md` — note `sub` rename and the FK warning.
+- Modify: `docs/resource-guide.md` (or wherever the public field-type table lives) — mirror the public version.
+- Modify: `docs/security.md` (or `docs/auth.md`) — document `sub` is opaque + don't FK it.
+- Modify: `CHANGELOG.md` — `[Unreleased]` section gets `Breaking` entries.
+
+---
+
+## Task 1: Branch off main
+
+Current branch is `fix/items-spec-and-migration-numbering` (a different fix). Per CLAUDE.md, never start feature work on main and never push more commits to a branch with an open PR.
+
+- [ ] **Step 1: Verify clean tree and switch to main**
+
+```bash
+git status
+git checkout main && git pull --ff-only
+```
+
+- [ ] **Step 2: Create the feature branch**
+
+```bash
+git checkout -b feat/v0.13.0-integer-and-auth-sub
+```
+
+Expected: switched to a new branch.
+
+---
+
+## Task 2: Fail-first test — `integer` field generates BIGINT
+
+Reproduce Issue 1 at the codegen layer. The test asserts the SQL emitted for an `integer` column is `BIGINT`, not `INTEGER`. This will fail today.
+
+**Files:**
+- Test: `shaperail-runtime/src/db/query.rs` (existing `mod tests` near bottom — add new test there)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module of `shaperail-runtime/src/db/query.rs`:
+
+```rust
+#[test]
+fn integer_field_emits_bigint() {
+    use shaperail_core::FieldType;
+    let f = default_field();
+    assert_eq!(field_type_to_sql(&FieldType::Integer, &f), "BIGINT");
+}
+```
+
+(`default_field()` is the existing helper at the bottom of the same `tests` module — reuse it.)
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+cargo test -p shaperail-runtime --lib db::query::tests::integer_field_emits_bigint
+```
+
+Expected: `assertion failed: "INTEGER" == "BIGINT"`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add shaperail-runtime/src/db/query.rs
+git commit -m "test(shaperail-runtime): assert integer field emits BIGINT (will fail until codegen fix)"
+```
+
+---
+
+## Task 3: Make `Integer` 64-bit in `shaperail-core`
+
+The single source-of-truth change. `Integer`'s Rust type becomes `i64`. `Bigint` variant is deleted entirely.
+
+**Files:**
+- Modify: `shaperail-core/src/field_type.rs`
+
+- [ ] **Step 1: Edit `FieldType` to drop `Bigint` and change `Integer` to i64**
+
+Replace the existing `FieldType` enum, `to_rust_type`, `Display`, and tests block as follows.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FieldType {
+    Uuid,
+    String,
+    /// 64-bit signed integer. Maps to Postgres `BIGINT` and Rust `i64`.
+    Integer,
+    /// 64-bit floating point (SQL DOUBLE PRECISION / NUMERIC).
+    Number,
+    Boolean,
+    Timestamp,
+    Date,
+    Enum,
+    Json,
+    Array,
+    File,
+}
+
+impl FieldType {
+    pub fn to_rust_type(&self, required: bool, nullable: bool, generated: bool) -> String {
+        let base = match self {
+            Self::Uuid => "uuid::Uuid",
+            Self::String | Self::Enum | Self::File => "String",
+            Self::Integer => "i64",
+            Self::Number => "f64",
+            Self::Boolean => "bool",
+            Self::Timestamp => "chrono::DateTime<chrono::Utc>",
+            Self::Date => "chrono::NaiveDate",
+            Self::Json => "serde_json::Value",
+            Self::Array => "Vec<serde_json::Value>",
+        };
+        if nullable || generated || !required {
+            format!("Option<{base}>")
+        } else {
+            base.to_string()
+        }
+    }
+}
+
+impl std::fmt::Display for FieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Uuid => "uuid",
+            Self::String => "string",
+            Self::Integer => "integer",
+            Self::Number => "number",
+            Self::Boolean => "boolean",
+            Self::Timestamp => "timestamp",
+            Self::Date => "date",
+            Self::Enum => "enum",
+            Self::Json => "json",
+            Self::Array => "array",
+            Self::File => "file",
+        };
+        write!(f, "{s}")
+    }
+}
+```
+
+Update the `tests` module in the same file: drop the `assert_eq!(FieldType::Bigint.to_string(), "bigint");` line, drop `FieldType::Bigint` from the variants vec in `field_type_serde_roundtrip`, and add `assert_eq!(FieldType::Integer.to_rust_type(true, false, false), "i64");`.
+
+- [ ] **Step 2: Run `shaperail-core` tests**
+
+```bash
+cargo test -p shaperail-core
+```
+
+Expected: pass. (Workspace will not yet compile because consumers still reference `Bigint`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add shaperail-core/src/field_type.rs
+git commit -m "feat(shaperail-core)!: integer field becomes 64-bit; remove bigint variant"
+```
+
+---
+
+## Task 4: Update validator — accept the `bigint` keyword as an explicit error
+
+When a user writes `type: bigint`, deserialization will now fail (not a known variant). We want a *friendly* error, not a parse error.
+
+**Files:**
+- Modify: `shaperail-codegen/src/validator.rs`
+
+- [ ] **Step 1: Find where field types are deserialized**
+
+```bash
+grep -n "FieldType\|parse_field_type\|unknown.*type\|type:.*bigint" shaperail-codegen/src/validator.rs | head
+```
+
+Identify the function that resolves a field's type string. Add a pre-check: if the raw YAML value for `type` equals `"bigint"`, return a domain validation error with code `E_BIGINT_REMOVED` and message:
+
+```
+type 'bigint' was removed in v0.13.0 — use 'integer' (now 64-bit by default).
+```
+
+If the validator goes through serde's `deserialize` directly, intercept by wrapping in a custom deserializer that maps `"bigint"` → an explicit error string. Look for the resource_format YAML loader in `shaperail-codegen/src/parser.rs` if validator.rs doesn't own the deserialization.
+
+- [ ] **Step 2: Drop existing `Bigint` references in validator.rs**
+
+Search and replace:
+
+```bash
+grep -n "FieldType::Bigint" shaperail-codegen/src/validator.rs
+```
+
+Each `[FieldType::Integer, FieldType::Bigint]` slice becomes `[FieldType::Integer]`. Each `FieldType::Bigint =>` arm is removed.
+
+- [ ] **Step 3: Add validator test for the friendly error**
+
+In the `tests` module of `validator.rs`, add a test that loads a resource YAML with `field: { type: bigint }` and asserts the error message contains `"removed in v0.13.0"` and `"use 'integer'"`.
+
+- [ ] **Step 4: Run validator tests**
+
+```bash
+cargo test -p shaperail-codegen --lib validator
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shaperail-codegen/src/validator.rs
+git commit -m "feat(shaperail-codegen)!: friendly error for removed 'bigint' field type"
+```
+
+---
+
+## Task 5: Fanout — `shaperail-codegen` non-validator files
+
+Drop `FieldType::Bigint` arms. For arms where `Integer` had a different mapping than `Bigint`, change `Integer` to use the old `Bigint` mapping (because `Integer` is now 64-bit).
+
+**Files:**
+- Modify: `shaperail-codegen/src/rust.rs`
+- Modify: `shaperail-codegen/src/openapi.rs`
+- Modify: `shaperail-codegen/src/typescript.rs`
+- Modify: `shaperail-codegen/src/json_schema.rs`
+- Modify: `shaperail-codegen/src/proto.rs`
+
+- [ ] **Step 1: Edit `rust.rs`**
+
+Two locations:
+1. Line ~1208: change the parser hint for `FieldType::Integer` from `text.parse::<i32>()...` to `text.parse::<i64>()...` and adjust the error string to `"invalid integer filter"`. Delete the `FieldType::Bigint =>` arm immediately below.
+2. Line ~1272: change the SQL type string for `FieldType::Integer` from `"integer".to_string()` to `"bigint".to_string()`. Delete the `FieldType::Bigint =>` arm.
+3. Line ~1281: change `Some(FieldType::Integer) => "integer[]"` to `Some(FieldType::Integer) => "bigint[]"`. Delete the `Some(FieldType::Bigint) =>` arm.
+
+- [ ] **Step 2: Edit `openapi.rs`**
+
+In the field-type → OpenAPI mapping (around line 276):
+
+Replace
+```rust
+FieldType::Integer => "integer",
+FieldType::Bigint => "integer",
+```
+with
+```rust
+FieldType::Integer => "integer",
+```
+And in the surrounding object insertion (lines ~239–242 region), if `format: int64` isn't already emitted for `Integer`, emit it. Search for where `format` is set for integer and ensure `Integer` produces `format: int64`.
+
+- [ ] **Step 3: Edit `typescript.rs`**
+
+Line ~138: the existing `(Some("integer"), _) | (Some("number"), _) => "number"` pattern matches the lowercased `Display` form, so removing `Bigint` from the enum already takes care of it. Search the file for `bigint` and remove any explicit arm.
+
+```bash
+grep -n "bigint\|Bigint" shaperail-codegen/src/typescript.rs
+```
+
+Delete lines as needed.
+
+- [ ] **Step 4: Edit `json_schema.rs`**
+
+Two `enum: ["uuid", "string", "integer", "bigint", ...]` literals (lines ~61 and ~134). Drop `"bigint"` from both. Verify no schemas elsewhere in the file reference `bigint`.
+
+- [ ] **Step 5: Edit `proto.rs`**
+
+Line ~13: change `FieldType::Integer => "int32"` to `FieldType::Integer => "int64"`. Delete the `FieldType::Bigint => "int64"` arm.
+
+In the same file's tests (line ~331), update the assertion to `assert_eq!(field_type_to_proto(&FieldType::Integer), "int64");` and delete the `Bigint` assertion.
+
+- [ ] **Step 6: Build and test the codegen crate**
+
+```bash
+cargo test -p shaperail-codegen
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shaperail-codegen/src/rust.rs shaperail-codegen/src/openapi.rs shaperail-codegen/src/typescript.rs shaperail-codegen/src/json_schema.rs shaperail-codegen/src/proto.rs
+git commit -m "feat(shaperail-codegen)!: integer maps to bigint/int64 across all code generators"
+```
+
+---
+
+## Task 6: Fanout — `shaperail-runtime` Issue-1 sites
+
+**Files:**
+- Modify: `shaperail-runtime/src/db/query.rs`
+- Modify: `shaperail-runtime/src/grpc/codec.rs`
+- Modify: `shaperail-runtime/src/db/mongo.rs`
+- Modify: `shaperail-runtime/src/graphql/schema.rs`
+- Modify: `shaperail-runtime/src/handlers/validate.rs`
+- Modify: `shaperail-runtime/src/handlers/crud.rs`
+
+- [ ] **Step 1: Edit `db/query.rs`**
+
+There are four `field_type_to_sql`-style functions. In each:
+1. Change `FieldType::Integer => "INTEGER".to_string()` to `FieldType::Integer => "BIGINT".to_string()`.
+2. Delete the `FieldType::Bigint =>` arm.
+
+Specifically the lines to edit (per earlier grep): 1015, 1027, 1056, 1080–1081. For 1080–1081 (which had Integer→INTEGER and Bigint→INTEGER both), keep just `Integer => "BIGINT"`. For 1083 (`Boolean => "INTEGER"`) — leave that alone, it's an unrelated SQLite quirk for booleans.
+
+Also at lines 422, 546, 590:
+- Line 422 region: `FieldType::Integer => { ... value.as_i64() ... as i32 }` — change the cast to `as i64` (or just remove the cast). Delete the `Bigint` arm immediately below.
+- Line 546: change `BindValue::Int(value.as_i64().unwrap_or(0) as i32)` for the Integer arm to `BindValue::Bigint(value.as_i64().unwrap_or(0))`. Delete the Bigint line. (Verify the `BindValue` enum still has `Bigint`; if `Int` is the i32 variant and `Bigint` is the i64 variant, rename internally if you wish, but the minimal change is just to point Integer at the i64 variant.)
+- Line 590: same kind of collapse.
+
+If `BindValue::Int` becomes orphaned (no variants reference it), delete the variant.
+
+- [ ] **Step 2: Run the test from Task 2**
+
+```bash
+cargo test -p shaperail-runtime --lib db::query::tests::integer_field_emits_bigint
+```
+
+Expected: PASS now.
+
+- [ ] **Step 3: Edit `grpc/codec.rs`**
+
+Lines 40–47 and 176: `FieldType::Integer` arm stays but now should accept `i64` range. The existing code at line 40 does `n.as_i64()` already — fine. Delete the `FieldType::Bigint` arm at line 47. At line 176, ditto.
+
+In the test fixtures at lines 280, 304, no change needed — they already use `Integer`.
+
+- [ ] **Step 4: Edit `db/mongo.rs`**
+
+Line 160–161: change `FieldType::Integer => "int"` to `FieldType::Integer => "long"`; delete the Bigint arm.
+Line 179–180: change `FieldType::Integer => Bson::Int32(...)` to `FieldType::Integer => Bson::Int64(value.as_i64().unwrap_or(0))`; delete the Bigint arm.
+
+- [ ] **Step 5: Edit `graphql/schema.rs`**
+
+Line 43–44: `FieldType::Integer => TypeRef::named("Int")` is fine (GraphQL `Int` is 32-bit by spec, but most servers extend; keep as-is for now and document the caveat in `agent_docs/codegen-patterns.md`). Delete the `FieldType::Bigint` arm.
+
+- [ ] **Step 6: Edit `handlers/validate.rs`**
+
+Lines 143–144 and 265: `FieldType::Integer | FieldType::Bigint` — collapse to just `FieldType::Integer`.
+
+Line 732 (test fixture): no change needed, already uses Integer.
+
+- [ ] **Step 7: Edit `handlers/crud.rs`**
+
+Lines 1453–1459: keep the Integer arm but make it use `as_i64()` directly (no truncation). Delete the Bigint arm.
+
+- [ ] **Step 8: Build and test the runtime crate (Issue 1 portion)**
+
+```bash
+cargo build -p shaperail-runtime
+cargo test -p shaperail-runtime --lib
+```
+
+Expected: pass. (Integration tests `tests/api_integration.rs` line 202 references `FieldType::Bigint` — that gets fixed in this step too: change to `FieldType::Integer`.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add shaperail-runtime/src
+git add shaperail-runtime/tests/api_integration.rs
+git commit -m "feat(shaperail-runtime)!: integer field binds as i64 and emits BIGINT"
+```
+
+---
+
+## Task 7: Fail-first test — `AuthenticatedUser.sub` rename
+
+Add a test that uses the new field name. It will fail to compile until Task 8 lands.
+
+**Files:**
+- Test: `shaperail-runtime/src/auth/extractor.rs` (existing tests module)
+
+- [ ] **Step 1: Update the existing test to use `sub`**
+
+Replace the `authenticated_user_debug` test with the new name and field reference:
+
+```rust
+#[test]
+fn authenticated_user_uses_sub_field() {
+    let user = AuthenticatedUser {
+        sub: "u1".to_string(),
+        role: "admin".to_string(),
+        tenant_id: None,
+    };
+    assert_eq!(user.sub, "u1");
+    let cloned = user.clone();
+    assert_eq!(cloned.sub, "u1");
+}
+```
+
+- [ ] **Step 2: Confirm it fails to compile**
+
+```bash
+cargo test -p shaperail-runtime --lib auth::extractor::tests
+```
+
+Expected: compile error — `no field 'sub'`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add shaperail-runtime/src/auth/extractor.rs
+git commit -m "test(shaperail-runtime): assert AuthenticatedUser exposes 'sub' (will fail until rename)"
+```
+
+---
+
+## Task 8: Rename `AuthenticatedUser.id` → `sub` and `Subject.id` → `sub`
+
+Mechanical rename across the runtime.
+
+**Files:**
+- Modify: `shaperail-runtime/src/auth/extractor.rs`
+- Modify: `shaperail-runtime/src/auth/subject.rs`
+- Modify: `shaperail-runtime/src/auth/rbac.rs`
+- Modify: `shaperail-runtime/src/auth/api_key.rs`
+- Modify: `shaperail-runtime/src/grpc/server.rs`
+- Modify: `shaperail-runtime/src/grpc/interceptor.rs`
+- Modify: `shaperail-runtime/tests/handler_tests.rs`
+
+- [ ] **Step 1: Edit `auth/extractor.rs`**
+
+Update the struct, doctest, and both extract paths.
+
+```rust
+/// Authenticated subject extracted from a valid JWT Bearer token or API key.
+///
+/// Use as an Actix-web extractor in handler signatures:
+/// ```no_run
+/// use actix_web::Responder;
+/// use shaperail_runtime::auth::AuthenticatedUser;
+///
+/// async fn handler(user: AuthenticatedUser) -> impl Responder {
+///     format!("Hello, subject {}", user.sub)
+/// }
+/// ```
+/// Returns 401 if no valid JWT or API key is present.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    /// The JWT `sub` claim (RFC 7519). **Opaque identifier** — do NOT bind this
+    /// directly to a foreign-key column without first verifying it maps to a row.
+    /// For platform-level roles like `super_admin`, `sub` is a routable identity
+    /// that does NOT exist in the `users` table.
+    pub sub: String,
+    /// The user's role (from JWT `role` claim or API key mapping).
+    pub role: String,
+    /// The user's tenant ID (M18). Present when multi-tenancy is enabled.
+    pub tenant_id: Option<String>,
+}
+```
+
+In `extract_auth`, change the two `AuthenticatedUser { id: claims.sub, ... }` constructions to `AuthenticatedUser { sub: claims.sub, ... }`.
+
+- [ ] **Step 2: Edit `auth/subject.rs`**
+
+```rust
+#[derive(Debug, Clone)]
+pub struct Subject {
+    /// The JWT `sub` claim — opaque per RFC 7519. See `AuthenticatedUser::sub`.
+    pub sub: String,
+    pub role: String,
+    pub tenant_id: Option<String>,
+}
+```
+
+Update the `From<&AuthenticatedUser>` impl: `sub: user.sub.clone()`. Update test fixtures and any `subject.id` reference inside this file.
+
+- [ ] **Step 3: Edit `auth/rbac.rs`**
+
+Replace `user.id` with `user.sub` in production code (e.g. line 62, `Some(owner_id) if owner_id == user.sub`) and comment (line 53). Update test fixtures (`AuthenticatedUser { id: ... }` → `AuthenticatedUser { sub: ... }`) at lines 99–117 and 169–180.
+
+- [ ] **Step 4: Edit `auth/api_key.rs`**
+
+Update the test fixture at line 71: `assert_eq!(user.sub, "user-1");` and any `id: ...` constructor.
+
+- [ ] **Step 5: Edit `grpc/server.rs` and `grpc/interceptor.rs`**
+
+Both files do `Some(AuthenticatedUser { id: claims.sub, ... })`. Change `id:` to `sub:`. Update test assertions (`user.sub`).
+
+- [ ] **Step 6: Edit `tests/handler_tests.rs`**
+
+Update fixtures at lines 546–567 and 636–647 to use `sub:`. Update assertion at line 709 to `assert_eq!(user.sub, "user-1");`.
+
+- [ ] **Step 7: Build the runtime crate**
+
+```bash
+cargo build -p shaperail-runtime --tests
+```
+
+Expected: clean build.
+
+- [ ] **Step 8: Run all runtime tests**
+
+```bash
+cargo test -p shaperail-runtime
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add shaperail-runtime
+git commit -m "feat(shaperail-runtime)!: rename AuthenticatedUser.id and Subject.id to sub (RFC 7519)"
+```
+
+---
+
+## Task 9: Update example resource YAMLs
+
+Replace `bigint` with `integer` in every example.
+
+**Files:**
+- Modify: `examples/enterprise-saas/resources/invoices.yaml`
+- Modify: `examples/enterprise-saas/resources/customers.yaml`
+- Modify: `examples/enterprise-saas/resources/payments.yaml`
+- Modify: `examples/incident-platform/resources/attachments.yaml`
+
+- [ ] **Step 1: Replace in each file**
+
+For each file above, change `type: bigint` → `type: integer`. Six total occurrences (3+1+1+1).
+
+- [ ] **Step 2: Regenerate the examples to confirm codegen succeeds**
+
+```bash
+cargo build -p shaperail-cli
+./target/debug/shaperail check examples/enterprise-saas
+./target/debug/shaperail check examples/incident-platform
+```
+
+Expected: both pass with no validation errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples
+git commit -m "feat(shaperail-cli)!: examples use integer (now 64-bit) instead of removed bigint"
+```
+
+(Note: the `examples` scope is internal-only per CLAUDE.md release-plz rules; release-plz won't trigger a release on this commit alone, but bundled with the previous breaking commits, the v0.13.0 bump is already locked in.)
+
+---
+
+## Task 10: Docs — internal + public mirror
+
+Per CLAUDE.md "Public-mirror requirement", every `agent_docs` change needs a corresponding `docs/` change.
+
+**Files:**
+- Modify: `agent_docs/resource-format.md`
+- Modify: `agent_docs/auth-claims.md`
+- Modify: `docs/resource-guide.md` (or whichever public page documents field types — search first)
+- Modify: `docs/security.md` (or `docs/auth.md`)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Find the public field-type page**
+
+```bash
+grep -ln "field type\|FieldType\|integer\|bigint" docs/*.md | head
+```
+
+Expect `docs/resource-guide.md` to be the canonical public page. If a different file is the field-type table, edit that instead.
+
+- [ ] **Step 2: Update `agent_docs/resource-format.md`**
+
+Drop the `bigint` row from the field-type table. Update the `integer` row description to:
+
+> 64-bit signed integer. Maps to Postgres `BIGINT`, Rust `i64`, OpenAPI `format: int64`. Range: ±9.2 × 10¹⁸. Suitable for currency in minor units.
+
+Add a "Migrating from v0.12" callout: "type `bigint` was removed in v0.13.0; use `integer` (now 64-bit by default)."
+
+- [ ] **Step 3: Mirror in `docs/resource-guide.md`**
+
+Same change in user-facing voice.
+
+- [ ] **Step 4: Update `agent_docs/auth-claims.md`**
+
+Add a section "JWT `sub` is opaque" stating that `AuthenticatedUser.sub` and `Subject.sub` hold the unprocessed JWT `sub` claim, that per RFC 7519 it has no defined relationship to any database row, and that custom handlers MUST NOT bind it to FK columns without verifying the row exists. Show the `super_admin` failure mode.
+
+- [ ] **Step 5: Mirror in `docs/security.md`**
+
+Same content, public voice.
+
+- [ ] **Step 6: Update `CHANGELOG.md`**
+
+Under `[Unreleased]`, add:
+
+```markdown
+### Breaking
+
+- `integer` field type now maps to Postgres `BIGINT` and Rust `i64` (was `INTEGER` / `i32`). The `bigint` type has been removed — use `integer` everywhere. Resources using `type: bigint` get a friendly validator error pointing at the new spelling. Motivation: i32::MAX cents is ~$21M USD, far below practical money limits, and the framework can't know which integer columns are money-shaped.
+- `AuthenticatedUser.id` renamed to `AuthenticatedUser.sub`; `Subject.id` renamed to `Subject.sub`. The field holds the JWT `sub` claim (opaque per RFC 7519) — never bind it to a foreign-key column without verifying. Migration: rename `user.id` → `user.sub` at every call site.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent_docs docs CHANGELOG.md
+git commit -m "docs: v0.13.0 — integer is 64-bit; AuthenticatedUser uses sub"
+```
+
+---
+
+## Task 11: Full quality gate
+
+- [ ] **Step 1: Format**
+
+```bash
+cargo fmt --all
+```
+
+- [ ] **Step 2: Build the workspace**
+
+```bash
+cargo build --workspace --all-targets
+```
+
+Expected: clean build, no warnings about unused `Bigint` or `id` references.
+
+- [ ] **Step 3: Clippy**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 4: Tests**
+
+```bash
+cargo test --workspace
+```
+
+Expected: all pass. (As of v0.12.0 there are 452 tests; this should be similar after the rename — no tests should be deleted, only updated.)
+
+- [ ] **Step 5: Commit any formatting fixups**
+
+```bash
+git status
+git add -u
+git diff --cached --stat
+git commit -m "style: cargo fmt after v0.13.0 changes" || true
+```
+
+(`|| true` because there may be no diff to commit.)
+
+---
+
+## Task 12: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/v0.13.0-integer-and-auth-sub
+```
+
+- [ ] **Step 2: Open the PR with conventional-commit title**
+
+```bash
+gh pr create --title "feat!: v0.13.0 — integer defaults to 64-bit; AuthenticatedUser uses sub" --body "$(cat <<'EOF'
+## Summary
+
+Resolves two GitHub-reported v0.12.0 bugs as a single breaking release.
+
+### Issue 1 — `integer` codegens to Postgres INTEGER (i32::MAX cap)
+- `FieldType::Integer` is now 64-bit: maps to Postgres `BIGINT`, Rust `i64`, OpenAPI `format: int64`.
+- `FieldType::Bigint` is removed. Resources using `type: bigint` get a friendly validator error (`E_BIGINT_REMOVED`) pointing at the new spelling.
+
+### Issue 2 — `AuthenticatedUser.id` is the JWT sub, not a users.id
+- `AuthenticatedUser.id` → `AuthenticatedUser.sub`; `Subject.id` → `Subject.sub`.
+- Doc comments now state explicitly that `sub` is opaque per RFC 7519 and MUST NOT be bound to FK columns without verifying.
+
+## Test plan
+- [ ] `cargo build --workspace --all-targets` clean
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] `cargo test --workspace` — all 452+ pass
+- [ ] `shaperail check examples/enterprise-saas` and `examples/incident-platform` pass after YAML migration
+- [ ] Validator emits friendly error for `type: bigint`
+- [ ] CHANGELOG `[Unreleased]` lists both breaking changes under `Breaking`
+
+## Migration
+
+```diff
+- max_minor: { type: bigint, required: true }
++ max_minor: { type: integer, required: true }   # now 64-bit by default
+```
+
+```diff
+- let reviewer = Uuid::parse_str(&auth.id).ok();
++ let reviewer = Uuid::parse_str(&auth.sub).ok();
++ // Note: 'sub' is opaque (RFC 7519). For super_admin it does not map to users.id.
++ // Verify before binding to FK columns.
+```
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Print the PR URL**
+
+```bash
+gh pr view --json url -q .url
+```
+
+---
+
+## Self-review checklist
+
+Spec coverage: ✅ Issue 1 → Tasks 2–6, 9. Issue 2 → Tasks 7–8. Docs → Task 10. Quality gate → Task 11. PR → Task 12.
+
+Placeholder scan: ✅ no TBD, TODO, "implement later", or "fill in details". Every code edit shows the actual code or the precise grep + line-by-line replacement.
+
+Type consistency: ✅ `AuthenticatedUser.sub` and `Subject.sub` consistently named across Tasks 7–8. `FieldType::Integer` (i64/BIGINT) consistent across all codegen and runtime tasks.
+
+Open question for executor: if `BindValue::Int` ends up unused after Task 6, delete the variant; if other code paths still need an i32 binder, leave it. Decide based on `grep` after the fanout.

--- a/agent_docs/resource-format.md
+++ b/agent_docs/resource-format.md
@@ -33,8 +33,7 @@ schema:
 |-------------|-----------------|------------------------|------------------------------|
 | `uuid`      | UUID            | Uuid                   | use for all IDs              |
 | `string`    | TEXT/VARCHAR(n) | String                 | add `max:` for VARCHAR       |
-| `integer`   | INTEGER         | i32                    |                              |
-| `bigint`    | BIGINT          | i64                    |                              |
+| `integer`   | BIGINT          | i64                    | 64-bit signed; use for currency in minor units |
 | `number`    | NUMERIC(p,s)    | f64                    |                              |
 | `boolean`   | BOOLEAN         | bool                   |                              |
 | `timestamp` | TIMESTAMPTZ     | DateTime<Utc>          | always with timezone         |
@@ -43,6 +42,8 @@ schema:
 | `json`      | JSONB           | serde_json::Value      |                              |
 | `array`     | type[]          | Vec<T>                 | add `items: type`            |
 | `file`      | TEXT (URL)      | FileRef                | stored in storage backend    |
+
+> **Migrating from v0.12.** The `bigint` type was removed in v0.13.0. Use `integer` everywhere — it is now 64-bit by default. Resources still using `type: bigint` will fail validation with `E_BIGINT_REMOVED` and a migration hint. Motivation: i32::MAX cents is ~$21M USD, far below practical money limits, and the framework can't tell which integer columns are money-shaped, so the safer default wins.
 
 ### Array element constraints
 

--- a/docs/resource-guide.md
+++ b/docs/resource-guide.md
@@ -156,8 +156,7 @@ Schema fields use compact inline objects. Every attribute:
 | --- | --- | --- | --- |
 | `uuid` | `UUID` | `uuid::Uuid` | Use for primary keys and foreign keys |
 | `string` | `VARCHAR(max)` or `TEXT` | `String` | Supports `min`, `max`, `format` |
-| `integer` | `INTEGER` | `i32` | 32-bit signed |
-| `bigint` | `BIGINT` | `i64` | 64-bit signed |
+| `integer` | `BIGINT` | `i64` | 64-bit signed (range ±9.2 × 10¹⁸). Use for currency in minor units. |
 | `number` | `NUMERIC` | `f64` | 64-bit floating point |
 | `boolean` | `BOOLEAN` | `bool` | |
 | `timestamp` | `TIMESTAMPTZ` | `chrono::DateTime<Utc>` | Use `generated: true` for auto timestamps |
@@ -166,6 +165,8 @@ Schema fields use compact inline objects. Every attribute:
 | `json` | `JSONB` | `serde_json::Value` | Arbitrary JSON |
 | `array` | varies | `Vec<T>` | Requires `items` for element type |
 | `file` | `TEXT` | `String` | Stores file URL. Use with `upload:` on endpoints |
+
+> **Migrating from v0.12.** The `bigint` type was removed in v0.13.0. Use `integer` everywhere — it is now 64-bit by default. Resources still declaring `type: bigint` fail validation with `E_BIGINT_REMOVED`. Motivation: `i32::MAX` cents is ~$21M USD, which silently caps any money-shaped column.
 
 ### Array element constraints
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -147,7 +147,7 @@ re-exported from the auth module):
 
 | Claim | Required for | Notes |
 | --- | --- | --- |
-| `sub` | always | User ID, typically a UUID. |
+| `sub` | always | Opaque subject identifier per RFC 7519. For tenant roles this is conventionally a `users.id` UUID; for `super_admin` it is a routable identity that does NOT exist in `users`. **Do NOT bind `sub` to a foreign-key column without verifying.** Exposed in custom handlers as `AuthenticatedUser.sub` and `Subject.sub` (renamed from `.id` in v0.13.0). |
 | `role` | always | Must match a role in any endpoint's `auth:` list, or be `super_admin` for unrestricted access. |
 | `iat` / `exp` | always | Unix seconds. |
 | `token_type` | always | `"access"` for protected requests; `"refresh"` is only valid against the refresh endpoint. |

--- a/examples/enterprise-saas/resources/customers.yaml
+++ b/examples/enterprise-saas/resources/customers.yaml
@@ -8,7 +8,7 @@ schema:
   name:               { type: string, min: 1, max: 200, required: true }
   email:              { type: string, format: email, required: true }
   plan:               { type: enum, values: [free, starter, pro, enterprise], default: free }
-  credit_limit_cents: { type: bigint, default: 0 }
+  credit_limit_cents: { type: integer, default: 0 }
   stripe_customer_id: { type: string, nullable: true }
   status:             { type: enum, values: [active, suspended, closed], default: active }
   created_by:         { type: uuid, required: true }

--- a/examples/enterprise-saas/resources/invoices.yaml
+++ b/examples/enterprise-saas/resources/invoices.yaml
@@ -8,9 +8,9 @@ schema:
   customer_id:    { type: uuid, ref: customers.id, required: true }
   invoice_number: { type: string, unique: true, required: true }
   status:         { type: enum, values: [draft, pending, sent, paid, overdue, void], default: draft }
-  subtotal_cents: { type: bigint, required: true }
-  tax_cents:      { type: bigint, default: 0 }
-  total_cents:    { type: bigint, required: true }
+  subtotal_cents: { type: integer, required: true }
+  tax_cents:      { type: integer, default: 0 }
+  total_cents:    { type: integer, required: true }
   due_date:       { type: date, required: true }
   sent_at:        { type: timestamp, nullable: true }
   paid_at:        { type: timestamp, nullable: true }

--- a/examples/enterprise-saas/resources/payments.yaml
+++ b/examples/enterprise-saas/resources/payments.yaml
@@ -6,7 +6,7 @@ schema:
   id:               { type: uuid, primary: true, generated: true }
   org_id:           { type: uuid, required: true }
   invoice_id:       { type: uuid, ref: invoices.id, required: true }
-  amount_cents:     { type: bigint, required: true }
+  amount_cents:     { type: integer, required: true }
   method:           { type: enum, values: [card, bank_transfer, check], required: true }
   reference_number: { type: string, nullable: true }
   status:           { type: enum, values: [pending, completed, failed, refunded], default: pending }

--- a/examples/incident-platform/resources/attachments.yaml
+++ b/examples/incident-platform/resources/attachments.yaml
@@ -10,7 +10,7 @@ schema:
   file_url:            { type: file, required: true }
   file_url_filename:   { type: string, nullable: true }
   file_url_mime_type:  { type: string, nullable: true }
-  file_url_size:       { type: bigint, nullable: true }
+  file_url_size:       { type: integer, nullable: true }
   created_by:          { type: uuid, required: true }
   created_at:          { type: timestamp, generated: true }
   updated_at:          { type: timestamp, generated: true }

--- a/shaperail-codegen/src/diagnostics.rs
+++ b/shaperail-codegen/src/diagnostics.rs
@@ -746,7 +746,7 @@ endpoints:
 
     #[test]
     fn format_feature_warnings_empty_returns_empty_string() {
-        use crate::feature_check::{format_feature_warnings, RequiredFeature};
+        use crate::feature_check::format_feature_warnings;
         let s = format_feature_warnings(&[]);
         assert!(s.is_empty());
     }

--- a/shaperail-codegen/src/json_schema.rs
+++ b/shaperail-codegen/src/json_schema.rs
@@ -58,7 +58,7 @@ pub fn generate_resource_json_schema() -> Value {
         "$defs": {
             "FieldType": {
                 "type": "string",
-                "enum": ["uuid", "string", "integer", "bigint", "number", "boolean", "timestamp", "date", "enum", "json", "array", "file"],
+                "enum": ["uuid", "string", "integer", "number", "boolean", "timestamp", "date", "enum", "json", "array", "file"],
                 "description": "The data type of a field."
             },
             "FieldSchema": {
@@ -131,7 +131,7 @@ pub fn generate_resource_json_schema() -> Value {
                     "items": {
                         "type": "string",
                         "description": "Element type for array fields. Required when type is 'array'.",
-                        "enum": ["uuid", "string", "integer", "bigint", "number", "boolean", "timestamp", "date"]
+                        "enum": ["uuid", "string", "integer", "number", "boolean", "timestamp", "date"]
                     }
                 }
             },
@@ -342,7 +342,7 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .len()
-                == 12
+                == 11
         );
     }
 

--- a/shaperail-codegen/src/openapi.rs
+++ b/shaperail-codegen/src/openapi.rs
@@ -237,9 +237,6 @@ fn field_schema_to_openapi(schema: &FieldSchema) -> serde_json::Value {
         }
         FieldType::Integer => {
             obj.insert("type".to_string(), serde_json::json!("integer"));
-        }
-        FieldType::Bigint => {
-            obj.insert("type".to_string(), serde_json::json!("integer"));
             obj.insert("format".to_string(), serde_json::json!("int64"));
         }
         FieldType::Number => {
@@ -274,7 +271,6 @@ fn field_schema_to_openapi(schema: &FieldSchema) -> serde_json::Value {
                         "string"
                     }
                     FieldType::Integer => "integer",
-                    FieldType::Bigint => "integer",
                     FieldType::Number => "number",
                     FieldType::Boolean => "boolean",
                     FieldType::Timestamp | FieldType::Date => "string",
@@ -339,7 +335,7 @@ fn field_schema_to_openapi(schema: &FieldSchema) -> serde_json::Value {
             FieldType::String => {
                 obj.insert("minLength".to_string(), min.clone());
             }
-            FieldType::Integer | FieldType::Bigint | FieldType::Number => {
+            FieldType::Integer | FieldType::Number => {
                 obj.insert("minimum".to_string(), min.clone());
             }
             _ => {}
@@ -350,7 +346,7 @@ fn field_schema_to_openapi(schema: &FieldSchema) -> serde_json::Value {
             FieldType::String => {
                 obj.insert("maxLength".to_string(), max.clone());
             }
-            FieldType::Integer | FieldType::Bigint | FieldType::Number => {
+            FieldType::Integer | FieldType::Number => {
                 obj.insert("maximum".to_string(), max.clone());
             }
             _ => {}

--- a/shaperail-codegen/src/parser.rs
+++ b/shaperail-codegen/src/parser.rs
@@ -12,6 +12,13 @@ pub enum ParseError {
     #[error("{0}")]
     ConfigInterpolation(String),
 
+    /// A removed field type was used. Provides a friendly migration message.
+    #[error("[{code}] {message}")]
+    RemovedType {
+        code: &'static str,
+        message: &'static str,
+    },
+
     #[error("{file}: {source}")]
     Context {
         file: String,
@@ -26,6 +33,15 @@ pub enum ParseError {
 /// endpoint names (list, get, create, update, delete), `method` and `path`
 /// are inferred from the resource name if not explicitly provided.
 pub fn parse_resource(yaml: &str) -> Result<ResourceDefinition, ParseError> {
+    // Pre-check: detect removed `bigint` field type before serde deserialization
+    // so we can emit a friendly error instead of an opaque "unknown variant" message.
+    if yaml.contains("type: bigint") {
+        return Err(ParseError::RemovedType {
+            code: "E_BIGINT_REMOVED",
+            message:
+                "type 'bigint' was removed in v0.13.0 — use 'integer' (now 64-bit by default).",
+        });
+    }
     let mut resource: ResourceDefinition = serde_yaml::from_str(yaml)?;
     shaperail_core::apply_endpoint_defaults(&mut resource);
     Ok(resource)

--- a/shaperail-codegen/src/proto.rs
+++ b/shaperail-codegen/src/proto.rs
@@ -10,8 +10,7 @@ fn field_type_to_proto(ft: &FieldType) -> &'static str {
     match ft {
         FieldType::Uuid => "string",
         FieldType::String => "string",
-        FieldType::Integer => "int32",
-        FieldType::Bigint => "int64",
+        FieldType::Integer => "int64",
         FieldType::Number => "double",
         FieldType::Boolean => "bool",
         FieldType::Timestamp => "google.protobuf.Timestamp",
@@ -328,8 +327,7 @@ mod tests {
     fn field_type_mapping() {
         assert_eq!(field_type_to_proto(&FieldType::Uuid), "string");
         assert_eq!(field_type_to_proto(&FieldType::String), "string");
-        assert_eq!(field_type_to_proto(&FieldType::Integer), "int32");
-        assert_eq!(field_type_to_proto(&FieldType::Bigint), "int64");
+        assert_eq!(field_type_to_proto(&FieldType::Integer), "int64");
         assert_eq!(field_type_to_proto(&FieldType::Number), "double");
         assert_eq!(field_type_to_proto(&FieldType::Boolean), "bool");
         assert_eq!(

--- a/shaperail-codegen/src/rust.rs
+++ b/shaperail-codegen/src/rust.rs
@@ -1205,8 +1205,7 @@ fn generate_filter_declaration(field_name: &str, field: &FieldSchema) -> String 
     let parser = match field.field_type {
         FieldType::Uuid => "uuid::Uuid::parse_str(text).map_err(|_| shaperail_core::ShaperailError::Internal(\"invalid uuid filter\".to_string()))",
         FieldType::String | FieldType::Enum | FieldType::File => "Ok(text.to_string())",
-        FieldType::Integer => "text.parse::<i32>().map_err(|_| shaperail_core::ShaperailError::Internal(\"invalid integer filter\".to_string()))",
-        FieldType::Bigint => "text.parse::<i64>().map_err(|_| shaperail_core::ShaperailError::Internal(\"invalid bigint filter\".to_string()))",
+        FieldType::Integer => "text.parse::<i64>().map_err(|_| shaperail_core::ShaperailError::Internal(\"invalid integer filter\".to_string()))",
         FieldType::Number => "text.parse::<f64>().map_err(|_| shaperail_core::ShaperailError::Internal(\"invalid number filter\".to_string()))",
         FieldType::Boolean => "text.parse::<bool>().map_err(|_| shaperail_core::ShaperailError::Internal(\"invalid boolean filter\".to_string()))",
         FieldType::Timestamp => "chrono::DateTime::parse_from_rfc3339(text).map(|value| value.with_timezone(&chrono::Utc)).map_err(|_| shaperail_core::ShaperailError::Internal(\"invalid timestamp filter\".to_string()))",
@@ -1269,8 +1268,7 @@ fn sql_cast_type(field: &FieldSchema) -> String {
     match field.field_type {
         FieldType::Uuid => "uuid".to_string(),
         FieldType::String | FieldType::Enum | FieldType::File => "text".to_string(),
-        FieldType::Integer => "integer".to_string(),
-        FieldType::Bigint => "bigint".to_string(),
+        FieldType::Integer => "bigint".to_string(),
         FieldType::Number => "double precision".to_string(),
         FieldType::Boolean => "boolean".to_string(),
         FieldType::Timestamp => "timestamptz".to_string(),
@@ -1278,8 +1276,7 @@ fn sql_cast_type(field: &FieldSchema) -> String {
         FieldType::Json => "jsonb".to_string(),
         FieldType::Array => match field.items.as_ref().map(|i| &i.field_type) {
             Some(FieldType::Uuid) => "uuid[]".to_string(),
-            Some(FieldType::Integer) => "integer[]".to_string(),
-            Some(FieldType::Bigint) => "bigint[]".to_string(),
+            Some(FieldType::Integer) => "bigint[]".to_string(),
             Some(FieldType::Number) => "double precision[]".to_string(),
             Some(FieldType::Boolean) => "boolean[]".to_string(),
             Some(FieldType::Timestamp) => "timestamptz[]".to_string(),
@@ -1293,8 +1290,7 @@ fn query_type(field: &FieldSchema) -> String {
     match field.field_type {
         FieldType::Uuid => "uuid::Uuid".to_string(),
         FieldType::String | FieldType::Enum | FieldType::File => "String".to_string(),
-        FieldType::Integer => "i32".to_string(),
-        FieldType::Bigint => "i64".to_string(),
+        FieldType::Integer => "i64".to_string(),
         FieldType::Number => "f64".to_string(),
         FieldType::Boolean => "bool".to_string(),
         FieldType::Timestamp => "chrono::DateTime<chrono::Utc>".to_string(),
@@ -1302,8 +1298,7 @@ fn query_type(field: &FieldSchema) -> String {
         FieldType::Json => "serde_json::Value".to_string(),
         FieldType::Array => match field.items.as_ref().map(|i| &i.field_type) {
             Some(FieldType::Uuid) => "Vec<uuid::Uuid>".to_string(),
-            Some(FieldType::Integer) => "Vec<i32>".to_string(),
-            Some(FieldType::Bigint) => "Vec<i64>".to_string(),
+            Some(FieldType::Integer) => "Vec<i64>".to_string(),
             Some(FieldType::Number) => "Vec<f64>".to_string(),
             Some(FieldType::Boolean) => "Vec<bool>".to_string(),
             Some(FieldType::Timestamp) => "Vec<chrono::DateTime<chrono::Utc>>".to_string(),
@@ -1371,9 +1366,6 @@ fn default_expression(
             format!("{value:?}.to_string()")
         }
         FieldType::Integer => format!(
-            "parse_embedded_json::<i32>({field_name:?}, serde_json::json!({default}))?"
-        ),
-        FieldType::Bigint => format!(
             "parse_embedded_json::<i64>({field_name:?}, serde_json::json!({default}))?"
         ),
         FieldType::Number => format!(

--- a/shaperail-codegen/src/validator.rs
+++ b/shaperail-codegen/src/validator.rs
@@ -380,7 +380,7 @@ pub fn validate_resource(rd: &ResourceDefinition) -> Vec<ValidationError> {
                 for (suffix, expected_types) in [
                     ("filename", &[FieldType::String][..]),
                     ("mime_type", &[FieldType::String][..]),
-                    ("size", &[FieldType::Integer, FieldType::Bigint][..]),
+                    ("size", &[FieldType::Integer][..]),
                 ] {
                     let companion = format!("{}_{}", upload.field, suffix);
                     if let Some(field) = rd.schema.get(&companion) {
@@ -826,7 +826,7 @@ schema:
   file: { type: file, required: true }
   file_filename: { type: string }
   file_mime_type: { type: string }
-  file_size: { type: bigint }
+  file_size: { type: integer }
   updated_at: { type: timestamp, generated: true }
 endpoints:
   upload:
@@ -1793,5 +1793,30 @@ endpoints:
         let errors = validate_resource(&rd);
         // No errors related to this field.
         assert!(errors.iter().all(|e| !e.message.contains("tags")));
+    }
+
+    #[test]
+    fn bigint_type_produces_friendly_error() {
+        let yaml = r#"
+resource: invoices
+version: 1
+schema:
+  id: { type: uuid, primary: true, generated: true }
+  amount_cents: { type: bigint, required: true }
+"#;
+        let err = parse_resource(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("removed in v0.13.0"),
+            "Expected removal message, got: {msg}"
+        );
+        assert!(
+            msg.contains("use 'integer'"),
+            "Expected migration hint, got: {msg}"
+        );
+        assert!(
+            msg.contains("E_BIGINT_REMOVED"),
+            "Expected error code, got: {msg}"
+        );
     }
 }

--- a/shaperail-core/src/field_type.rs
+++ b/shaperail-core/src/field_type.rs
@@ -8,11 +8,9 @@ pub enum FieldType {
     Uuid,
     /// Variable-length text. Use `max` constraint for VARCHAR(n).
     String,
-    /// 32-bit signed integer.
+    /// 64-bit signed integer. Maps to Postgres `BIGINT` and Rust `i64`.
     Integer,
-    /// 64-bit signed integer.
-    Bigint,
-    /// 64-bit floating point (SQL NUMERIC).
+    /// 64-bit floating point (SQL DOUBLE PRECISION / NUMERIC).
     Number,
     /// Boolean true/false.
     Boolean,
@@ -36,8 +34,7 @@ impl FieldType {
         let base = match self {
             Self::Uuid => "uuid::Uuid",
             Self::String | Self::Enum | Self::File => "String",
-            Self::Integer => "i32",
-            Self::Bigint => "i64",
+            Self::Integer => "i64",
             Self::Number => "f64",
             Self::Boolean => "bool",
             Self::Timestamp => "chrono::DateTime<chrono::Utc>",
@@ -59,7 +56,6 @@ impl std::fmt::Display for FieldType {
             Self::Uuid => "uuid",
             Self::String => "string",
             Self::Integer => "integer",
-            Self::Bigint => "bigint",
             Self::Number => "number",
             Self::Boolean => "boolean",
             Self::Timestamp => "timestamp",
@@ -82,7 +78,6 @@ mod tests {
         assert_eq!(FieldType::Uuid.to_string(), "uuid");
         assert_eq!(FieldType::String.to_string(), "string");
         assert_eq!(FieldType::Integer.to_string(), "integer");
-        assert_eq!(FieldType::Bigint.to_string(), "bigint");
         assert_eq!(FieldType::Number.to_string(), "number");
         assert_eq!(FieldType::Boolean.to_string(), "boolean");
         assert_eq!(FieldType::Timestamp.to_string(), "timestamp");
@@ -99,7 +94,6 @@ mod tests {
             FieldType::Uuid,
             FieldType::String,
             FieldType::Integer,
-            FieldType::Bigint,
             FieldType::Number,
             FieldType::Boolean,
             FieldType::Timestamp,
@@ -138,8 +132,7 @@ mod tests {
         let cases: &[(&FieldType, &str)] = &[
             (&FieldType::Uuid, "uuid::Uuid"),
             (&FieldType::String, "String"),
-            (&FieldType::Integer, "i32"),
-            (&FieldType::Bigint, "i64"),
+            (&FieldType::Integer, "i64"),
             (&FieldType::Number, "f64"),
             (&FieldType::Boolean, "bool"),
             (&FieldType::Timestamp, "chrono::DateTime<chrono::Utc>"),
@@ -162,7 +155,7 @@ mod tests {
     fn to_rust_type_wrapped_when_nullable() {
         assert_eq!(
             FieldType::Integer.to_rust_type(true, true, false),
-            "Option<i32>"
+            "Option<i64>"
         );
         assert_eq!(
             FieldType::Uuid.to_rust_type(true, true, false),
@@ -190,5 +183,10 @@ mod tests {
             FieldType::Date.to_rust_type(true, false, false),
             "chrono::NaiveDate"
         );
+    }
+
+    #[test]
+    fn integer_is_i64() {
+        assert_eq!(FieldType::Integer.to_rust_type(true, false, false), "i64");
     }
 }

--- a/shaperail-runtime/src/auth/api_key.rs
+++ b/shaperail-runtime/src/auth/api_key.rs
@@ -24,7 +24,7 @@ impl ApiKeyStore {
         self.keys.insert(
             key,
             AuthenticatedUser {
-                id: user_id,
+                sub: user_id,
                 role,
                 tenant_id: None,
             },
@@ -68,7 +68,7 @@ mod tests {
         let user = store.lookup("sk-test-123");
         assert!(user.is_some());
         let user = user.unwrap();
-        assert_eq!(user.id, "user-1");
+        assert_eq!(user.sub, "user-1");
         assert_eq!(user.role, "admin");
     }
 

--- a/shaperail-runtime/src/auth/extractor.rs
+++ b/shaperail-runtime/src/auth/extractor.rs
@@ -8,7 +8,7 @@ use shaperail_core::ShaperailError;
 use super::api_key::ApiKeyStore;
 use super::jwt::JwtConfig;
 
-/// Authenticated user extracted from a valid JWT Bearer token or API key.
+/// Authenticated subject extracted from a valid JWT Bearer token or API key.
 ///
 /// Use as an Actix-web extractor in handler signatures:
 /// ```no_run
@@ -16,14 +16,17 @@ use super::jwt::JwtConfig;
 /// use shaperail_runtime::auth::AuthenticatedUser;
 ///
 /// async fn handler(user: AuthenticatedUser) -> impl Responder {
-///     format!("Hello, user {}", user.id)
+///     format!("Hello, subject {}", user.sub)
 /// }
 /// ```
 /// Returns 401 if no valid JWT or API key is present.
 #[derive(Debug, Clone)]
 pub struct AuthenticatedUser {
-    /// The user's unique ID (from JWT `sub` claim or API key mapping).
-    pub id: String,
+    /// The JWT `sub` claim (RFC 7519). **Opaque identifier** — do NOT bind this
+    /// directly to a foreign-key column without first verifying it maps to a row.
+    /// For platform-level roles like `super_admin`, `sub` is a routable identity
+    /// that does NOT exist in the `users` table.
+    pub sub: String,
     /// The user's role (from JWT `role` claim or API key mapping).
     pub role: String,
     /// The user's tenant ID (M18). Present when multi-tenancy is enabled.
@@ -70,7 +73,7 @@ fn extract_auth(req: &HttpRequest) -> Result<AuthenticatedUser, ShaperailError> 
                 return Err(ShaperailError::Unauthorized);
             }
             return Ok(AuthenticatedUser {
-                id: claims.sub,
+                sub: claims.sub,
                 role: claims.role,
                 tenant_id: claims.tenant_id,
             });
@@ -166,7 +169,7 @@ mod tests {
             "valid JWT must yield an authenticated user"
         );
         let user = result.unwrap();
-        assert_eq!(user.id, "user-42");
+        assert_eq!(user.sub, "user-42");
         assert_eq!(user.role, "member");
     }
 

--- a/shaperail-runtime/src/auth/extractor.rs
+++ b/shaperail-runtime/src/auth/extractor.rs
@@ -104,17 +104,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn authenticated_user_debug() {
+    fn authenticated_user_uses_sub_field() {
         let user = AuthenticatedUser {
-            id: "u1".to_string(),
+            sub: "u1".to_string(),
             role: "admin".to_string(),
             tenant_id: None,
         };
-        assert_eq!(user.id, "u1");
-        assert_eq!(user.role, "admin");
-        // Clone works
+        assert_eq!(user.sub, "u1");
         let cloned = user.clone();
-        assert_eq!(cloned.id, "u1");
+        assert_eq!(cloned.sub, "u1");
     }
 
     #[test]

--- a/shaperail-runtime/src/auth/rbac.rs
+++ b/shaperail-runtime/src/auth/rbac.rs
@@ -50,7 +50,7 @@ pub fn enforce(
 
 /// Checks if the authenticated user owns the given resource record.
 ///
-/// Looks for a `created_by` field in the record and compares it to `user.id`.
+/// Looks for a `created_by` field in the record and compares it to `user.sub`.
 /// Returns `Ok(())` if the user is the owner, `Err(Forbidden)` otherwise.
 pub fn check_owner(
     user: &AuthenticatedUser,
@@ -59,7 +59,7 @@ pub fn check_owner(
     let created_by = record.get("created_by").and_then(|v| v.as_str());
 
     match created_by {
-        Some(owner_id) if owner_id == user.id => Ok(()),
+        Some(owner_id) if owner_id == user.sub => Ok(()),
         _ => Err(ShaperailError::Forbidden),
     }
 }
@@ -98,7 +98,7 @@ mod tests {
 
     fn admin_user() -> AuthenticatedUser {
         AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "admin".to_string(),
             tenant_id: None,
         }
@@ -106,7 +106,7 @@ mod tests {
 
     fn member_user() -> AuthenticatedUser {
         AuthenticatedUser {
-            id: "user-2".to_string(),
+            sub: "user-2".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         }
@@ -114,7 +114,7 @@ mod tests {
 
     fn viewer_user() -> AuthenticatedUser {
         AuthenticatedUser {
-            id: "user-3".to_string(),
+            sub: "user-3".to_string(),
             role: "viewer".to_string(),
             tenant_id: None,
         }
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn check_owner_matches() {
         let user = AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         };
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn check_owner_rejects_other() {
         let user = AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         };

--- a/shaperail-runtime/src/auth/subject.rs
+++ b/shaperail-runtime/src/auth/subject.rs
@@ -33,7 +33,8 @@ use super::extractor::AuthenticatedUser;
 /// ```
 #[derive(Debug, Clone)]
 pub struct Subject {
-    pub id: String,
+    /// The JWT `sub` claim — opaque per RFC 7519. See `AuthenticatedUser::sub`.
+    pub sub: String,
     pub role: String,
     pub tenant_id: Option<String>,
 }
@@ -106,7 +107,7 @@ impl Subject {
 impl From<&AuthenticatedUser> for Subject {
     fn from(user: &AuthenticatedUser) -> Self {
         Self {
-            id: user.id.clone(),
+            sub: user.sub.clone(),
             role: user.role.clone(),
             tenant_id: user.tenant_id.clone(),
         }
@@ -125,7 +126,7 @@ mod tests {
 
     fn super_admin() -> Subject {
         Subject {
-            id: "u1".into(),
+            sub: "u1".into(),
             role: "super_admin".into(),
             tenant_id: None,
         }
@@ -133,7 +134,7 @@ mod tests {
 
     fn member(tenant: &str) -> Subject {
         Subject {
-            id: "u2".into(),
+            sub: "u2".into(),
             role: "member".into(),
             tenant_id: Some(tenant.into()),
         }
@@ -141,7 +142,7 @@ mod tests {
 
     fn member_no_tenant() -> Subject {
         Subject {
-            id: "u3".into(),
+            sub: "u3".into(),
             role: "member".into(),
             tenant_id: None,
         }
@@ -218,7 +219,7 @@ mod tests {
     #[test]
     fn is_super_admin_false_for_admin_role() {
         let s = Subject {
-            id: "u1".into(),
+            sub: "u1".into(),
             role: "admin".into(),
             tenant_id: Some("org-1".into()),
         };
@@ -229,7 +230,7 @@ mod tests {
     fn empty_string_tenant_id_treated_as_missing() {
         // tenant_id = Some("") is semantically "not set"
         let s = Subject {
-            id: "u1".into(),
+            sub: "u1".into(),
             role: "member".into(),
             tenant_id: Some(String::new()),
         };
@@ -256,12 +257,12 @@ mod tests {
         use super::super::extractor::AuthenticatedUser;
 
         let user = AuthenticatedUser {
-            id: "u-99".into(),
+            sub: "u-99".into(),
             role: "viewer".into(),
             tenant_id: Some("org-42".into()),
         };
         let subject = Subject::from(user);
-        assert_eq!(subject.id, "u-99");
+        assert_eq!(subject.sub, "u-99");
         assert_eq!(subject.role, "viewer");
         assert_eq!(subject.tenant_id.as_deref(), Some("org-42"));
     }
@@ -270,7 +271,7 @@ mod tests {
     fn subject_clone() {
         let s = member("org-1");
         let c = s.clone();
-        assert_eq!(c.id, s.id);
+        assert_eq!(c.sub, s.sub);
         assert_eq!(c.role, s.role);
         assert_eq!(c.tenant_id, s.tenant_id);
     }
@@ -279,7 +280,7 @@ mod tests {
     fn assert_tenant_match_empty_string_record_tenant() {
         // Even if record_tenant is empty, it must match if subject tenant is also empty
         let s = Subject {
-            id: "u1".into(),
+            sub: "u1".into(),
             role: "super_admin".into(),
             tenant_id: None,
         };

--- a/shaperail-runtime/src/db/mongo.rs
+++ b/shaperail-runtime/src/db/mongo.rs
@@ -157,8 +157,7 @@ fn build_json_schema(resource: &ResourceDefinition) -> Document {
 fn field_type_to_bson_type(ft: &FieldType) -> &'static str {
     match ft {
         FieldType::Uuid | FieldType::String | FieldType::Enum | FieldType::File => "string",
-        FieldType::Integer => "int",
-        FieldType::Bigint => "long",
+        FieldType::Integer => "long",
         FieldType::Number => "double",
         FieldType::Boolean => "bool",
         FieldType::Timestamp | FieldType::Date => "string",
@@ -176,8 +175,7 @@ fn json_to_bson(value: &Value, field: &FieldSchema) -> Bson {
         FieldType::Uuid | FieldType::String | FieldType::Enum | FieldType::File => {
             Bson::String(value.as_str().unwrap_or(&value.to_string()).to_string())
         }
-        FieldType::Integer => Bson::Int32(value.as_i64().unwrap_or(0) as i32),
-        FieldType::Bigint => Bson::Int64(value.as_i64().unwrap_or(0)),
+        FieldType::Integer => Bson::Int64(value.as_i64().unwrap_or(0)),
         FieldType::Number => Bson::Double(value.as_f64().unwrap_or(0.0)),
         FieldType::Boolean => Bson::Boolean(value.as_bool().unwrap_or(false)),
         FieldType::Timestamp | FieldType::Date => {

--- a/shaperail-runtime/src/db/orm_query.rs
+++ b/shaperail-runtime/src/db/orm_query.rs
@@ -49,11 +49,6 @@ fn get_column_value(
                 .unwrap_or(serde_json::Value::Null))
         }
         FieldType::Integer => {
-            let v: Option<i32> = row.try_get("", name).map_err(map_err)?;
-            Ok(v.map(|n| serde_json::Value::Number(n.into()))
-                .unwrap_or(serde_json::Value::Null))
-        }
-        FieldType::Bigint => {
             let v: Option<i64> = row.try_get("", name).map_err(map_err)?;
             Ok(v.map(|n| serde_json::Value::Number(n.into()))
                 .unwrap_or(serde_json::Value::Null))
@@ -101,8 +96,7 @@ fn json_to_sea_value(value: &serde_json::Value, field: &FieldSchema) -> sea_quer
         FieldType::String | FieldType::Enum | FieldType::File => sea_query::Value::String(Some(
             Box::new(value.as_str().unwrap_or(&value.to_string()).to_string()),
         )),
-        FieldType::Integer => sea_query::Value::Int(Some(value.as_i64().unwrap_or(0) as i32)),
-        FieldType::Bigint => sea_query::Value::BigInt(Some(value.as_i64().unwrap_or(0))),
+        FieldType::Integer => sea_query::Value::BigInt(Some(value.as_i64().unwrap_or(0))),
         FieldType::Number => sea_query::Value::Double(Some(value.as_f64().unwrap_or(0.0))),
         FieldType::Boolean => sea_query::Value::Bool(Some(value.as_bool().unwrap_or(false))),
         FieldType::Timestamp => sea_query::Value::String(Some(Box::new(
@@ -122,11 +116,6 @@ fn coerce_filter_to_sea_value(value: &str, field: &FieldSchema) -> sea_query::Va
             sea_query::Value::String(Some(Box::new(value.to_string())))
         }
         FieldType::Integer => value
-            .parse::<i32>()
-            .ok()
-            .map(|n| sea_query::Value::Int(Some(n)))
-            .unwrap_or_else(|| sea_query::Value::String(Some(Box::new(value.to_string())))),
-        FieldType::Bigint => value
             .parse::<i64>()
             .ok()
             .map(|n| sea_query::Value::BigInt(Some(n)))

--- a/shaperail-runtime/src/db/query.rs
+++ b/shaperail-runtime/src/db/query.rs
@@ -1488,4 +1488,32 @@ mod tests {
         let bind = json_to_bind(&serde_json::Value::Null, &str_field);
         assert!(matches!(bind, BindValue::Null));
     }
+
+    fn default_field() -> FieldSchema {
+        FieldSchema {
+            field_type: FieldType::String,
+            primary: false,
+            generated: false,
+            required: false,
+            unique: false,
+            nullable: false,
+            reference: None,
+            min: None,
+            max: None,
+            format: None,
+            values: None,
+            default: None,
+            sensitive: false,
+            search: false,
+            items: None,
+            transient: false,
+        }
+    }
+
+    #[test]
+    fn integer_field_emits_bigint() {
+        use shaperail_core::FieldType;
+        let f = default_field();
+        assert_eq!(field_type_to_sql(&FieldType::Integer, &f), "BIGINT");
+    }
 }

--- a/shaperail-runtime/src/db/query.rs
+++ b/shaperail-runtime/src/db/query.rs
@@ -420,11 +420,6 @@ impl<'a> ResourceQuery<'a> {
                     }
                 }
                 FieldType::Integer => {
-                    if let Ok(n) = value.parse::<i32>() {
-                        return BindValue::Int(n);
-                    }
-                }
-                FieldType::Bigint => {
                     if let Ok(n) = value.parse::<i64>() {
                         return BindValue::Bigint(n);
                     }
@@ -460,7 +455,6 @@ impl<'a> ResourceQuery<'a> {
         for bind in binds {
             query = match bind {
                 BindValue::Text(v) => query.bind(v),
-                BindValue::Int(v) => query.bind(v),
                 BindValue::Bigint(v) => query.bind(v),
                 BindValue::Float(v) => query.bind(v),
                 BindValue::Bool(v) => query.bind(v),
@@ -492,7 +486,6 @@ impl<'a> ResourceQuery<'a> {
         for bind in binds {
             query = match bind {
                 BindValue::Text(v) => query.bind(v),
-                BindValue::Int(v) => query.bind(v),
                 BindValue::Bigint(v) => query.bind(v),
                 BindValue::Float(v) => query.bind(v),
                 BindValue::Bool(v) => query.bind(v),
@@ -515,7 +508,6 @@ impl<'a> ResourceQuery<'a> {
 #[derive(Debug, Clone)]
 enum BindValue {
     Text(String),
-    Int(i32),
     Bigint(i64),
     Float(f64),
     Bool(bool),
@@ -543,8 +535,7 @@ fn json_to_bind(value: &serde_json::Value, field: &FieldSchema) -> BindValue {
         FieldType::String | FieldType::Enum | FieldType::File => {
             BindValue::Text(value.as_str().unwrap_or(&value.to_string()).to_string())
         }
-        FieldType::Integer => BindValue::Int(value.as_i64().unwrap_or(0) as i32),
-        FieldType::Bigint => BindValue::Bigint(value.as_i64().unwrap_or(0)),
+        FieldType::Integer => BindValue::Bigint(value.as_i64().unwrap_or(0)),
         FieldType::Number => BindValue::Float(value.as_f64().unwrap_or(0.0)),
         FieldType::Boolean => BindValue::Bool(value.as_bool().unwrap_or(false)),
         FieldType::Timestamp => {
@@ -588,11 +579,6 @@ fn extract_column_value(
                 .unwrap_or(serde_json::Value::Null))
         }
         FieldType::Integer => {
-            let v: Option<i32> = row.try_get(name).map_err(map_err)?;
-            Ok(v.map(|n| serde_json::Value::Number(n.into()))
-                .unwrap_or(serde_json::Value::Null))
-        }
-        FieldType::Bigint => {
             let v: Option<i64> = row.try_get(name).map_err(map_err)?;
             Ok(v.map(|n| serde_json::Value::Number(n.into()))
                 .unwrap_or(serde_json::Value::Null))
@@ -1012,8 +998,7 @@ fn field_type_to_sql(ft: &FieldType, field: &FieldSchema) -> String {
             }
             "TEXT".to_string()
         }
-        FieldType::Integer => "INTEGER".to_string(),
-        FieldType::Bigint => "BIGINT".to_string(),
+        FieldType::Integer => "BIGINT".to_string(),
         FieldType::Number => "NUMERIC".to_string(),
         FieldType::Boolean => "BOOLEAN".to_string(),
         FieldType::Timestamp => "TIMESTAMPTZ".to_string(),
@@ -1024,8 +1009,7 @@ fn field_type_to_sql(ft: &FieldType, field: &FieldSchema) -> String {
             if let Some(items) = &field.items {
                 let item_sql = match items.field_type {
                     FieldType::String | FieldType::Enum => "TEXT",
-                    FieldType::Integer => "INTEGER",
-                    FieldType::Bigint => "BIGINT",
+                    FieldType::Integer => "BIGINT",
                     FieldType::Number => "DOUBLE PRECISION",
                     FieldType::Boolean => "BOOLEAN",
                     FieldType::Timestamp => "TIMESTAMPTZ",
@@ -1053,8 +1037,7 @@ fn field_type_to_sql_mysql(ft: &FieldType, field: &FieldSchema) -> String {
             }
             "TEXT".to_string()
         }
-        FieldType::Integer => "INTEGER".to_string(),
-        FieldType::Bigint => "BIGINT".to_string(),
+        FieldType::Integer => "BIGINT".to_string(),
         FieldType::Number => "DECIMAL(65,30)".to_string(),
         FieldType::Boolean => "BOOLEAN".to_string(),
         FieldType::Timestamp => "DATETIME(6)".to_string(),
@@ -1078,7 +1061,6 @@ fn field_type_to_sql_sqlite(ft: &FieldType, field: &FieldSchema) -> String {
             "TEXT".to_string()
         }
         FieldType::Integer => "INTEGER".to_string(),
-        FieldType::Bigint => "INTEGER".to_string(),
         FieldType::Number => "REAL".to_string(),
         FieldType::Boolean => "INTEGER".to_string(),
         FieldType::Timestamp => "TEXT".to_string(),
@@ -1386,10 +1368,6 @@ mod tests {
         );
         assert_eq!(
             field_type_to_sql(&FieldType::Integer, &default_field),
-            "INTEGER"
-        );
-        assert_eq!(
-            field_type_to_sql(&FieldType::Bigint, &default_field),
             "BIGINT"
         );
         assert_eq!(

--- a/shaperail-runtime/src/graphql/schema.rs
+++ b/shaperail-runtime/src/graphql/schema.rs
@@ -41,7 +41,6 @@ fn field_type_to_type_ref(ft: &FieldType, _required: bool) -> TypeRef {
         FieldType::Uuid => TypeRef::named("String"),
         FieldType::String | FieldType::Enum | FieldType::File => TypeRef::named("String"),
         FieldType::Integer => TypeRef::named("Int"),
-        FieldType::Bigint => TypeRef::named("Int"),
         FieldType::Number => TypeRef::named("Float"),
         FieldType::Boolean => TypeRef::named("Boolean"),
         FieldType::Timestamp | FieldType::Date => TypeRef::named("String"),

--- a/shaperail-runtime/src/grpc/codec.rs
+++ b/shaperail-runtime/src/grpc/codec.rs
@@ -44,12 +44,6 @@ pub fn encode_field(
                 encode_varint(buf, v as u64);
             }
         }
-        (FieldType::Bigint, serde_json::Value::Number(n)) => {
-            if let Some(v) = n.as_i64() {
-                encode_varint(buf, encode_tag(field_number, WIRE_VARINT) as u64);
-                encode_varint(buf, v as u64);
-            }
-        }
         (FieldType::Number, serde_json::Value::Number(n)) => {
             if let Some(v) = n.as_f64() {
                 encode_varint(buf, encode_tag(field_number, WIRE_64BIT) as u64);
@@ -176,7 +170,7 @@ pub fn decode_resource_message(
                         FieldType::Integer => {
                             obj.insert(
                                 name.to_string(),
-                                serde_json::Value::Number(serde_json::Number::from(val as i32)),
+                                serde_json::Value::Number(serde_json::Number::from(val as i64)),
                             );
                         }
                         _ => {

--- a/shaperail-runtime/src/grpc/interceptor.rs
+++ b/shaperail-runtime/src/grpc/interceptor.rs
@@ -46,7 +46,7 @@ pub fn extract_grpc_auth(
     }
 
     Ok(Some(AuthenticatedUser {
-        id: claims.sub,
+        sub: claims.sub,
         role: claims.role,
         tenant_id: None,
     }))
@@ -99,7 +99,7 @@ mod tests {
 
         let result = extract_grpc_auth(&req, Some(&jwt));
         let user = result.unwrap().unwrap();
-        assert_eq!(user.id, "user-1");
+        assert_eq!(user.sub, "user-1");
         assert_eq!(user.role, "admin");
     }
 

--- a/shaperail-runtime/src/grpc/server.rs
+++ b/shaperail-runtime/src/grpc/server.rs
@@ -195,7 +195,7 @@ fn extract_user_from_headers(
         return None;
     }
     Some(AuthenticatedUser {
-        id: claims.sub,
+        sub: claims.sub,
         role: claims.role,
         tenant_id: None,
     })
@@ -410,7 +410,7 @@ mod tests {
         let user = extract_user_from_headers(&headers, Some(&jwt));
         assert!(user.is_some());
         let user = user.unwrap();
-        assert_eq!(user.id, "user-1");
+        assert_eq!(user.sub, "user-1");
         assert_eq!(user.role, "admin");
     }
 

--- a/shaperail-runtime/src/handlers/controller.rs
+++ b/shaperail-runtime/src/handlers/controller.rs
@@ -212,7 +212,7 @@ pub async fn dispatch_controller(
             input: ctx.input.clone(),
             data: ctx.data.clone(),
             user: ctx.user.as_ref().map(|u| PluginUser {
-                id: u.id.to_string(),
+                id: u.sub.to_string(),
                 role: u.role.clone(),
             }),
             headers: ctx.headers.clone(),

--- a/shaperail-runtime/src/handlers/crud.rs
+++ b/shaperail-runtime/src/handlers/crud.rs
@@ -274,7 +274,7 @@ async fn check_rate_limit(
         .peer_addr()
         .unwrap_or("unknown")
         .to_string();
-    let user_id = user.map(|u| u.id.as_str());
+    let user_id = user.map(|u| u.sub.as_str());
     let tenant_id = user.and_then(|u| u.tenant_id.as_deref());
     let base_key = crate::auth::RateLimiter::key_for_tenant(&ip, user_id, tenant_id);
     let key = format!("{resource_action}:{base_key}");
@@ -1658,7 +1658,7 @@ mod tests {
 
     fn user_with_tenant(id: &str, role: &str, tenant_id: &str) -> AuthenticatedUser {
         AuthenticatedUser {
-            id: id.to_string(),
+            sub: id.to_string(),
             role: role.to_string(),
             tenant_id: Some(tenant_id.to_string()),
         }
@@ -1700,7 +1700,7 @@ mod tests {
     fn verify_tenant_no_tenant_id_returns_forbidden() {
         let resource = tenant_resource();
         let user = AuthenticatedUser {
-            id: "u1".to_string(),
+            sub: "u1".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         };
@@ -1727,7 +1727,7 @@ mod tests {
     fn inject_tenant_filter_no_tenant_id_returns_forbidden() {
         let resource = tenant_resource();
         let user = AuthenticatedUser {
-            id: "u1".to_string(),
+            sub: "u1".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         };

--- a/shaperail-runtime/src/handlers/crud.rs
+++ b/shaperail-runtime/src/handlers/crud.rs
@@ -1451,16 +1451,10 @@ fn coerce_form_value(
         | shaperail_core::FieldType::Timestamp
         | shaperail_core::FieldType::Date => Ok(serde_json::Value::String(raw.to_string())),
         shaperail_core::FieldType::Integer => raw
-            .parse::<i32>()
-            .map(serde_json::Value::from)
-            .map_err(|_| {
-                multipart_field_error(field_name, "must be a valid integer", "invalid_integer")
-            }),
-        shaperail_core::FieldType::Bigint => raw
             .parse::<i64>()
             .map(serde_json::Value::from)
             .map_err(|_| {
-                multipart_field_error(field_name, "must be a valid integer", "invalid_bigint")
+                multipart_field_error(field_name, "must be a valid integer", "invalid_integer")
             }),
         shaperail_core::FieldType::Number => raw
             .parse::<f64>()

--- a/shaperail-runtime/src/handlers/routes.rs
+++ b/shaperail-runtime/src/handlers/routes.rs
@@ -311,7 +311,7 @@ mod tests {
 
     fn user_with_tenant(tenant_id: &str) -> AuthenticatedUser {
         AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "member".to_string(),
             tenant_id: Some(tenant_id.to_string()),
         }
@@ -413,7 +413,7 @@ mod tests {
     fn resolve_tenant_id_is_none_when_user_has_no_tenant_claim() {
         let resource = resource_with_tenant_key("org_id");
         let user = AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "super_admin".to_string(),
             tenant_id: None,
         };

--- a/shaperail-runtime/src/handlers/validate.rs
+++ b/shaperail-runtime/src/handlers/validate.rs
@@ -140,10 +140,7 @@ fn check_field_rules(
         }
     }
 
-    if field.field_type == FieldType::Integer
-        || field.field_type == FieldType::Bigint
-        || field.field_type == FieldType::Number
-    {
+    if field.field_type == FieldType::Integer || field.field_type == FieldType::Number {
         if let Some(n) = value.as_f64() {
             if let Some(min) = &field.min {
                 if let Some(min_val) = min.as_f64() {
@@ -260,10 +257,7 @@ fn check_item_rules(
     }
 
     // Numeric range checks
-    if matches!(
-        items.field_type,
-        FieldType::Integer | FieldType::Bigint | FieldType::Number
-    ) {
+    if matches!(items.field_type, FieldType::Integer | FieldType::Number) {
         if let Some(n) = value.as_f64() {
             if let Some(min) = items.min.as_ref().and_then(|v| v.as_f64()) {
                 if n < min {

--- a/shaperail-runtime/tests/api_integration.rs
+++ b/shaperail-runtime/tests/api_integration.rs
@@ -199,7 +199,7 @@ fn test_asset_resource() -> ResourceDefinition {
     schema.insert(
         "attachment_size".to_string(),
         FieldSchema {
-            field_type: FieldType::Bigint,
+            field_type: FieldType::Integer,
             primary: false,
             generated: false,
             required: false,

--- a/shaperail-runtime/tests/handler_tests.rs
+++ b/shaperail-runtime/tests/handler_tests.rs
@@ -545,7 +545,7 @@ mod auth_tests {
 
     fn admin_user() -> AuthenticatedUser {
         AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "admin".to_string(),
             tenant_id: None,
         }
@@ -553,7 +553,7 @@ mod auth_tests {
 
     fn member_user() -> AuthenticatedUser {
         AuthenticatedUser {
-            id: "user-2".to_string(),
+            sub: "user-2".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         }
@@ -561,7 +561,7 @@ mod auth_tests {
 
     fn viewer_user() -> AuthenticatedUser {
         AuthenticatedUser {
-            id: "user-3".to_string(),
+            sub: "user-3".to_string(),
             role: "viewer".to_string(),
             tenant_id: None,
         }
@@ -634,7 +634,7 @@ mod auth_tests {
     #[test]
     fn rbac_owner_allows_own() {
         let user = AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         };
@@ -645,7 +645,7 @@ mod auth_tests {
     #[test]
     fn rbac_owner_blocks_other() {
         let user = AuthenticatedUser {
-            id: "user-1".to_string(),
+            sub: "user-1".to_string(),
             role: "member".to_string(),
             tenant_id: None,
         };
@@ -706,7 +706,7 @@ mod auth_tests {
             "admin".to_string(),
         );
         let user = store.lookup("sk-test-key").unwrap();
-        assert_eq!(user.id, "user-1");
+        assert_eq!(user.sub, "user-1");
         assert_eq!(user.role, "admin");
     }
 


### PR DESCRIPTION
## Summary

Resolves two GitHub-reported v0.12.0 footguns as a single breaking release.

### Issue 1 — `integer` codegens to Postgres INTEGER (i32::MAX cap)

Money-shaped fields silently capped at ~$21M USD because `integer` mapped to `i32` / `INTEGER`. Fix:

- `FieldType::Integer` is now 64-bit: maps to Postgres `BIGINT`, Rust `i64`, OpenAPI `format: int64`, Protobuf `int64`, MongoDB `long`.
- `FieldType::Bigint` is removed — there is now ONE integer type (consistent with the framework's "ONE WAY" design rule).
- Resources still declaring `type: bigint` fail validation with `E_BIGINT_REMOVED` and a migration hint.

### Issue 2 — `AuthenticatedUser.id` is the JWT sub, not a users.id

The field name read like a database identifier and invited handlers to bind it to FK columns; for `super_admin` the JWT `sub` is a routable platform identity, not a `users` row, causing FK constraint violations under super_admin traffic. Fix:

- `AuthenticatedUser.id` → `AuthenticatedUser.sub`
- `Subject.id` → `Subject.sub`
- Doc comments now state explicitly that `sub` is opaque per RFC 7519 and MUST NOT be bound to FK columns without verifying the row exists.
- New `agent_docs/auth-claims.md` "JWT \`sub\` is opaque" section + public mirror in `docs/security.md` with the super-admin failure pattern.

## Migration

```diff
# resources/policies.yaml
- max_minor: { type: bigint, required: true }
+ max_minor: { type: integer, required: true }   # now 64-bit by default
```

```diff
// custom handler
- let reviewer = Uuid::parse_str(&auth.id).ok();
+ let reviewer = Uuid::parse_str(&auth.sub).ok();
+ // 'sub' is opaque (RFC 7519). For super_admin it is NOT a users.id —
+ // narrow FK assignments to roles whose sub is guaranteed to be a users row.
```

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 833 tests pass (with `DATABASE_URL` set for integration tests)
- [x] Fail-first test for Issue 1 (`integer_field_emits_bigint`) passes after Task 6 fanout
- [x] Fail-first test for Issue 2 (`authenticated_user_uses_sub_field`) passes after rename
- [x] Validator emits friendly `E_BIGINT_REMOVED` error for `type: bigint`
- [x] All 6 example YAMLs migrated from `bigint` to `integer`; `shaperail check` passes on `examples/enterprise-saas` and `examples/incident-platform`
- [x] CHANGELOG `[Unreleased]` lists both as `### Breaking`
- [x] `agent_docs/` and `docs/` mirrored per the public-mirror requirement

## Commits

| SHA | Subject |
|---|---|
| 3aafc33 | test(shaperail-runtime): assert integer field emits BIGINT |
| d995049 | feat(shaperail-core)!: integer field becomes 64-bit; remove bigint variant |
| 18186d6 | feat(shaperail-codegen)!: friendly error for removed 'bigint' field type |
| 54677b9 | feat(shaperail-codegen)!: integer maps to bigint/int64 across all code generators |
| a07c236 | feat(shaperail-runtime)!: integer field binds as i64 and emits BIGINT |
| 3b4f4b6 | feat(shaperail-cli)!: examples use integer instead of removed bigint |
| ee89cb7 | test(shaperail-runtime): assert AuthenticatedUser exposes 'sub' |
| b2ecf14 | feat(shaperail-runtime)!: rename AuthenticatedUser.id and Subject.id to sub (RFC 7519) |
| 346bd1f | docs: v0.13.0 — integer is 64-bit; AuthenticatedUser uses sub |
| 661b3fa | chore(shaperail-codegen): remove unused RequiredFeature import in diagnostics test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)