### PR TITLE
fix(release): manual 0.16.0 version bump to unstick release-plz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-codegen"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "indexmap",
  "insta",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4949,7 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "shaperail-runtime"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "actix-multipart",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -31,9 +31,9 @@ categories = ["web-programming::http-server", "development-tools"]
 # every consumer's Cargo.toml and release-plz's per-crate analysis can
 # leave some pins stale when a release bumps the workspace via
 # version_group but the consumer crate had no commits of its own.
-shaperail-core = { version = "0.15.0", path = "shaperail-core" }
-shaperail-codegen = { version = "0.15.0", path = "shaperail-codegen" }
-shaperail-runtime = { version = "0.15.0", path = "shaperail-runtime" }
+shaperail-core = { version = "0.16.0", path = "shaperail-core" }
+shaperail-codegen = { version = "0.16.0", path = "shaperail-codegen" }
+shaperail-runtime = { version = "0.16.0", path = "shaperail-runtime" }
 
 # Async
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Why this PR exists

The release-plz workflow on the merge of #105 failed with:

\`\`\`
error: failed to select a version for the requirement \`shaperail-core = "^0.15.0"\`
candidate versions found which didn't match: 0.16.0
\`\`\`

cargo-semver-checks correctly detected the additive struct-field changes in #105 (\`Diagnostic\` gained \`span\`/\`severity\`/\`doc_url\`) as breaking under standard semver — consumers constructing \`Diagnostic\` via exhaustive struct-literal break when fields are added. release-plz then bumped the workspace to 0.16.0 (correct), but its \`dependencies_update\` did NOT update the matching pins in \`[workspace.dependencies]\` (still said 0.15.0). \`shaperail-codegen v0.16.0\` then required \`shaperail-core ^0.15.0\` against a path-resolved 0.16.0, and \`cargo update\` aborted.

Same recurring pin-staleness pattern documented under the v0.12.0 release note in CHANGELOG.md.

## What this changes

- \`workspace.package.version\`: 0.15.0 → 0.16.0
- \`[workspace.dependencies]\` pins for shaperail-core/codegen/runtime: 0.15.0 → 0.16.0
- \`cargo build --workspace\` clean at 0.16.0

CHANGELOG.md is intentionally left as-is — release-plz will roll the \`[Unreleased]\` block into \`[0.16.0]\` on the next successful publish.

## Why \`fix(release):\` and not \`chore(release):\`

\`fix(release)\` is in release-plz's commit-parser skip list (per \`release-plz.toml\`), so this commit does not itself trigger an additional bump cycle. It changes pin numbers to match the version release-plz already wants, so the next release-plz run can complete cleanly.

## Follow-up

Add \`#[non_exhaustive]\` to \`Diagnostic\` and \`Span\` so future additive field additions stay strictly additive under cargo-semver-checks. That'll ship as a separate 0.16.1 patch.

## Test plan
- [x] \`cargo build --workspace\` passes
- [ ] After merge: release-plz workflow on main goes green
- [ ] After merge: \`cargo install shaperail-cli@0.16.0\` works
- [ ] After merge: \`gh release view v0.16.0\` shows the tag with binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)